### PR TITLE
Production-readiness fixes: billing idempotency, acceptance tokens, publish flow

### DIFF
--- a/.changeset/billing-idempotency-hardening.md
+++ b/.changeset/billing-idempotency-hardening.md
@@ -13,14 +13,25 @@ Production-readiness fixes for the billing engine and the prebuilt API.
   the same reference and reconciles the existing transaction instead of
   charging twice. The sweep also looks tx-less rows up by reference.
 - `subscribe` called twice while the first charge is in flight reuses the
-  same pending payment instead of minting a second one.
+  same pending payment instead of minting a second one. Resume charges are
+  numbered by a `resumeAttempts` counter on the subscription (new optional
+  field) and pending rows are found through a new
+  `payments.by_subscription_id_status` index.
+- A duplicate-reference rejection whose follow-up lookup fails leaves the
+  payment pending for the sweep instead of finalizing it as `error`; when
+  Wompi holds several transactions for one reference, an approved one wins,
+  then the newest.
 - Payments webhook: a redelivery whose first delivery crashed after being
   recorded is reprocessed instead of short-circuited.
 - `api().confirmTransaction` requires a signed-in user and redacts payments
   of other users; `api().checkout` now only accepts a catalog `productKey`
   (use `wompi.checkout(ctx, …)` server-side for custom amounts/metadata).
 - Both Wompi acceptance tokens (`acceptance_token`, `accept_personal_auth`)
-  are sent on payment sources and charges; `useWompiTokenizer` exposes
-  `personalDataAuthPermalink`; payment sources record `termsAcceptedAt`.
+  are sent on payment sources and charges — `subscribe` fails when the
+  merchant exposes only one; `useWompiTokenizer` exposes
+  `personalDataAuthPermalink` and clears both links when the client changes;
+  payment sources record `termsAcceptedAt`.
+- `registerRoutes({ onEvent })` is documented as at-least-once: make the
+  callback idempotent.
 - Packaging: `publishConfig.access` set, `react` peer dependency marked
   optional, `build` always cleans `dist`.

--- a/.changeset/billing-idempotency-hardening.md
+++ b/.changeset/billing-idempotency-hardening.md
@@ -1,0 +1,26 @@
+---
+"@pulgueta/wompi-convex": minor
+---
+
+Production-readiness fixes for the billing engine and the prebuilt API.
+
+- Payments: a declined, errored or expired row can still be approved (or
+  voided) by a later Wompi transaction that shares the reference — Web
+  Checkout payer retries no longer strand a paid order. Superseded
+  transaction ids are kept in `supersededTransactionIds`.
+- Charges whose response never arrived (timeout, 5xx, network) are left
+  pending instead of being finalized as `error`, so the next attempt reuses
+  the same reference and reconciles the existing transaction instead of
+  charging twice. The sweep also looks tx-less rows up by reference.
+- `subscribe` called twice while the first charge is in flight reuses the
+  same pending payment instead of minting a second one.
+- Payments webhook: a redelivery whose first delivery crashed after being
+  recorded is reprocessed instead of short-circuited.
+- `api().confirmTransaction` requires a signed-in user and redacts payments
+  of other users; `api().checkout` now only accepts a catalog `productKey`
+  (use `wompi.checkout(ctx, …)` server-side for custom amounts/metadata).
+- Both Wompi acceptance tokens (`acceptance_token`, `accept_personal_auth`)
+  are sent on payment sources and charges; `useWompiTokenizer` exposes
+  `personalDataAuthPermalink`; payment sources record `termsAcceptedAt`.
+- Packaging: `publishConfig.access` set, `react` peer dependency marked
+  optional, `build` always cleans `dist`.

--- a/.changeset/two-acceptance-tokens.md
+++ b/.changeset/two-acceptance-tokens.md
@@ -1,0 +1,10 @@
+---
+"@pulgueta/wompi": minor
+---
+
+Support Wompi's second acceptance token: `accept_personal_auth` on
+`createTransaction` / `createPaymentSource`, and `presigned_personal_data_auth`
+on the merchant response. Input schemas no longer strip documented fields —
+`taxes`, `ip`, `recurrent`, `parent_transaction_id` and `payment_description`
+now reach the API. Payment-source `type` and `status` widened for `DAVIPLATA`,
+`BANCOLOMBIA_TRANSFER` and `VOIDED`.

--- a/.changeset/two-acceptance-tokens.md
+++ b/.changeset/two-acceptance-tokens.md
@@ -4,7 +4,11 @@
 
 Support Wompi's second acceptance token: `accept_personal_auth` on
 `createTransaction` / `createPaymentSource`, and `presigned_personal_data_auth`
-on the merchant response. Input schemas no longer strip documented fields —
+on the merchant response. Both tokens are now **required** on those two
+inputs — a request without `accept_personal_auth` is rejected locally with
+`Invalid input` before anything is sent, matching Wompi's contract. Read the
+token from `merchant.presigned_personal_data_auth.acceptance_token` and show
+its `permalink` next to the terms link. Input schemas no longer strip documented fields —
 `taxes`, `ip`, `recurrent`, `parent_transaction_id` and `payment_description`
 now reach the API. Payment-source `type` and `status` widened for `DAVIPLATA`,
 `BANCOLOMBIA_TRANSFER` and `VOIDED`.

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,6 +30,23 @@ jobs:
       - name: Run tests
         run: pnpm test
 
+      # A tarball packed outside pnpm keeps `workspace:` specifiers, which
+      # makes the published package uninstallable. Pack every publishable
+      # package the same way the release does and inspect the manifest.
+      - name: Check publishable tarballs
+        run: |
+          set -euo pipefail
+          rm -rf /tmp/packs && mkdir -p /tmp/packs
+          for pkg in packages/core packages/convex-component; do
+            pnpm --filter "./$pkg" pack --pack-destination /tmp/packs
+          done
+          for tgz in /tmp/packs/*.tgz; do
+            if tar -xOf "$tgz" package/package.json | grep -q '"workspace:'; then
+              echo "::error::$tgz contains a workspace: dependency"
+              exit 1
+            fi
+          done
+
       - name: Run test coverage
         run: pnpm test:cov
 

--- a/apps/docs/content/docs/examples/card-checkout.mdx
+++ b/apps/docs/content/docs/examples/card-checkout.mdx
@@ -47,6 +47,7 @@ const signature = await getSignatureKey({ reference, amountInCents, integrityKey
 
 const [transactionError, transaction] = await wompi.transactions.createTransaction({
 acceptance_token: merchant.presigned_acceptance!.acceptance_token,
+accept_personal_auth: merchant.presigned_personal_data_auth!.acceptance_token,
 amount_in_cents: amountInCents,
 currency: "COP",
 signature,
@@ -91,6 +92,7 @@ integrityKey: process.env.WOMPI_INTEGRITY_KEY!,
 
 const [transactionError, transaction] = await wompi.transactions.createTransaction({
 acceptance_token: merchant.presigned_acceptance!.acceptance_token,
+accept_personal_auth: merchant.presigned_personal_data_auth!.acceptance_token,
 amount_in_cents: amountInCents,
 currency: "COP",
 signature,
@@ -141,6 +143,7 @@ integrityKey: process.env.WOMPI_INTEGRITY_KEY!,
 
 const [transactionError, transaction] = await wompi.transactions.createTransaction({
 acceptance_token: merchant.presigned_acceptance!.acceptance_token,
+accept_personal_auth: merchant.presigned_personal_data_auth!.acceptance_token,
 amount_in_cents: amountInCents,
 currency: "COP",
 signature,
@@ -185,6 +188,7 @@ integrityKey: Bun.env.WOMPI_INTEGRITY_KEY!,
 
 const [transactionError, transaction] = await wompi.transactions.createTransaction({
 acceptance_token: merchant.presigned_acceptance!.acceptance_token,
+accept_personal_auth: merchant.presigned_personal_data_auth!.acceptance_token,
 amount_in_cents: amountInCents,
 currency: "COP",
 signature,

--- a/apps/docs/content/docs/examples/card-checkout.mdx
+++ b/apps/docs/content/docs/examples/card-checkout.mdx
@@ -15,7 +15,7 @@ Each route uses `sandbox: true`. `4242 4242 4242 4242` is approved;
 
 ## Framework examples
 
-Four steps regardless of framework — fetch the acceptance token, tokenize the card, sign the amount, create the transaction. Pick your stack:
+Four steps regardless of framework — fetch both acceptance tokens, tokenize the card, sign the amount, create the transaction. Pick your stack:
 
 <Tabs>
 <Tab title="Astro">
@@ -39,6 +39,10 @@ sandbox: true,
 const [merchantError, merchant] = await wompi.merchants.getMerchant();
 if (merchantError) return Response.json({ error: merchantError.message }, { status: 502 });
 
+const acceptanceToken = merchant.presigned_acceptance?.acceptance_token;
+const personalAuthToken = merchant.presigned_personal_data_auth?.acceptance_token;
+if (!acceptanceToken || !personalAuthToken) return Response.json({ error: "Merchant has no acceptance tokens" }, { status: 502 });
+
 const [tokenError, token] = await wompi.tokens.tokenizeCard(card);
 if (tokenError) return Response.json({ error: tokenError.message }, { status: 422 });
 
@@ -46,8 +50,8 @@ const reference = `order-${Date.now()}`;
 const signature = await getSignatureKey({ reference, amountInCents, integrityKey: WOMPI_INTEGRITY_KEY });
 
 const [transactionError, transaction] = await wompi.transactions.createTransaction({
-acceptance_token: merchant.presigned_acceptance!.acceptance_token,
-accept_personal_auth: merchant.presigned_personal_data_auth!.acceptance_token,
+acceptance_token: acceptanceToken,
+accept_personal_auth: personalAuthToken,
 amount_in_cents: amountInCents,
 currency: "COP",
 signature,
@@ -80,6 +84,10 @@ sandbox: true,
 const [merchantError, merchant] = await wompi.merchants.getMerchant();
 if (merchantError) return NextResponse.json({ error: merchantError.message }, { status: 502 });
 
+const acceptanceToken = merchant.presigned_acceptance?.acceptance_token;
+const personalAuthToken = merchant.presigned_personal_data_auth?.acceptance_token;
+if (!acceptanceToken || !personalAuthToken) return NextResponse.json({ error: "Merchant has no acceptance tokens" }, { status: 502 });
+
 const [tokenError, token] = await wompi.tokens.tokenizeCard(card);
 if (tokenError) return NextResponse.json({ error: tokenError.message }, { status: 422 });
 
@@ -91,8 +99,8 @@ integrityKey: process.env.WOMPI_INTEGRITY_KEY!,
 });
 
 const [transactionError, transaction] = await wompi.transactions.createTransaction({
-acceptance_token: merchant.presigned_acceptance!.acceptance_token,
-accept_personal_auth: merchant.presigned_personal_data_auth!.acceptance_token,
+acceptance_token: acceptanceToken,
+accept_personal_auth: personalAuthToken,
 amount_in_cents: amountInCents,
 currency: "COP",
 signature,
@@ -131,6 +139,10 @@ sandbox: true,
 const [merchantError, merchant] = await wompi.merchants.getMerchant();
 if (merchantError) throw new Error(merchantError.message);
 
+const acceptanceToken = merchant.presigned_acceptance?.acceptance_token;
+const personalAuthToken = merchant.presigned_personal_data_auth?.acceptance_token;
+if (!acceptanceToken || !personalAuthToken) throw new Error("Merchant has no acceptance tokens");
+
 const [tokenError, token] = await wompi.tokens.tokenizeCard(card);
 if (tokenError) throw new Error(tokenError.message);
 
@@ -142,8 +154,8 @@ integrityKey: process.env.WOMPI_INTEGRITY_KEY!,
 });
 
 const [transactionError, transaction] = await wompi.transactions.createTransaction({
-acceptance_token: merchant.presigned_acceptance!.acceptance_token,
-accept_personal_auth: merchant.presigned_personal_data_auth!.acceptance_token,
+acceptance_token: acceptanceToken,
+accept_personal_auth: personalAuthToken,
 amount_in_cents: amountInCents,
 currency: "COP",
 signature,
@@ -176,6 +188,10 @@ sandbox: true,
 const [merchantError, merchant] = await wompi.merchants.getMerchant();
 if (merchantError) throw new Error(merchantError.message);
 
+const acceptanceToken = merchant.presigned_acceptance?.acceptance_token;
+const personalAuthToken = merchant.presigned_personal_data_auth?.acceptance_token;
+if (!acceptanceToken || !personalAuthToken) throw new Error("Merchant has no acceptance tokens");
+
 const [tokenError, token] = await wompi.tokens.tokenizeCard(card);
 if (tokenError) throw new Error(tokenError.message);
 
@@ -187,8 +203,8 @@ integrityKey: Bun.env.WOMPI_INTEGRITY_KEY!,
 });
 
 const [transactionError, transaction] = await wompi.transactions.createTransaction({
-acceptance_token: merchant.presigned_acceptance!.acceptance_token,
-accept_personal_auth: merchant.presigned_personal_data_auth!.acceptance_token,
+acceptance_token: acceptanceToken,
+accept_personal_auth: personalAuthToken,
 amount_in_cents: amountInCents,
 currency: "COP",
 signature,

--- a/apps/docs/content/docs/merchants.mdx
+++ b/apps/docs/content/docs/merchants.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: Merchants
 ---
 
-The merchant endpoint is the only one that needs no authentication header — the public key travels as part of the URL. Use it to fetch merchant metadata and, crucially, the presigned acceptance token you must include in every `createTransaction` call.
+The merchant endpoint is the only one that needs no authentication header — the public key travels as part of the URL. Use it to fetch merchant metadata and, crucially, the two presigned acceptance tokens you must include in every `createTransaction` call.
 
 ## getMerchant()
 
@@ -21,43 +21,53 @@ merchant.name; // string | undefined
 merchant.legal_name; // string | undefined
 merchant.accepted_payment_methods; // string[] | undefined
 merchant.presigned_acceptance?.acceptance_token; // string
+merchant.presigned_personal_data_auth?.acceptance_token; // string
 ```
 
 ## Response shape
 
-| Field                        | Type        | Notes                           |
-| ---------------------------- | ----------- | ------------------------------- |
-| `id`                         | `number`    | Wompi merchant id.              |
-| `name`                       | `string?`   | Public merchant name.           |
-| `legal_name`                 | `string?`   | Legal entity name.              |
-| `legal_id` / `legal_id_type` | `string?`   | `NIT` or `CC`.                  |
-| `accepted_payment_methods`   | `string[]?` | `"CARD"`, `"NEQUI"`, `"PSE"`, … |
-| `accepted_currencies`        | `"COP"[]?`  | Always `["COP"]` today.         |
-| `presigned_acceptance`       | `object?`   | See below.                      |
+| Field                          | Type        | Notes                           |
+| ------------------------------ | ----------- | ------------------------------- |
+| `id`                           | `number`    | Wompi merchant id.              |
+| `name`                         | `string?`   | Public merchant name.           |
+| `legal_name`                   | `string?`   | Legal entity name.              |
+| `legal_id` / `legal_id_type`   | `string?`   | `NIT` or `CC`.                  |
+| `accepted_payment_methods`     | `string[]?` | `"CARD"`, `"NEQUI"`, `"PSE"`, … |
+| `accepted_currencies`          | `"COP"[]?`  | Always `["COP"]` today.         |
+| `presigned_acceptance`         | `object?`   | See below.                      |
+| `presigned_personal_data_auth` | `object?`   | See below.                      |
 
 ## Presigned acceptance
 
-The `presigned_acceptance` object proves the customer accepted the merchant's end-user policy. Show `permalink` to the customer; pass `acceptance_token` when you create a transaction.
+Wompi asks the customer for two consents, and both objects have the same shape — `&#123; acceptance_token, permalink, type &#125;`:
+
+- `presigned_acceptance` — the merchant's end-user policy. `type` is `"END_USER_POLICY"`. Send it as `acceptance_token`.
+- `presigned_personal_data_auth` — the personal-data authorization. `type` is `"PERSONAL_DATA_AUTH"`. Send it as `accept_personal_auth`.
+
+Show both `permalink` values to the customer; pass both tokens to `createTransaction` and `createPaymentSource`.
 
 ```ts
 const [error, response] = await wompi.merchants.getMerchant();
 if (error) throw error;
 
 const acceptance = response.presigned_acceptance;
+const personalDataAuth = response.presigned_personal_data_auth;
 
 // Persist for the duration of a single transaction — Wompi rotates these.
 return {
-  token: acceptance?.acceptance_token,
+  acceptanceToken: acceptance?.acceptance_token,
   termsUrl: acceptance?.permalink,
+  personalAuthToken: personalDataAuth?.acceptance_token,
+  personalDataUrl: personalDataAuth?.permalink,
 };
 ```
 
 - `acceptance_token` — string, expires; fetch once per transaction.
-- `permalink` — URL to the merchant's terms.
-- `type` — always `"END_USER_POLICY"`.
+- `permalink` — URL to the merchant's terms or personal-data policy.
+- `type` — `"END_USER_POLICY"` or `"PERSONAL_DATA_AUTH"`.
 
 :::tip[Cache, but only briefly]
-The acceptance token is short-lived. Refetch it for every transaction rather than caching it
+Both tokens are short-lived. Refetch them for every transaction rather than caching them
 across requests — the request is fast and cheap, and a stale token is a guaranteed
 `INPUT_VALIDATION_ERROR`.
 :::

--- a/apps/docs/content/docs/payment-sources.mdx
+++ b/apps/docs/content/docs/payment-sources.mdx
@@ -14,7 +14,7 @@ Both methods on this resource require the private key. The SDK returns a
 
 ## createPaymentSource(input)
 
-Promote a one-time token into a reusable source. You'll need a fresh acceptance token from [`merchants.getMerchant()`](/docs/merchants) — Wompi treats this as a separate customer consent.
+Promote a one-time token into a reusable source. You'll need fresh acceptance tokens from [`merchants.getMerchant()`](/docs/merchants) — Wompi treats this as a separate customer consent.
 
 ```ts
 // 1. Tokenize the card (or Nequi account) up-front.
@@ -27,7 +27,7 @@ const [tokenError, token] = await wompi.tokens.tokenizeCard({
 });
 if (tokenError) throw tokenError;
 
-// 2. Fetch a fresh acceptance token from the merchant resource.
+// 2. Fetch fresh acceptance tokens from the merchant resource.
 const [merchantError, merchant] = await wompi.merchants.getMerchant();
 if (merchantError) throw merchantError;
 
@@ -36,7 +36,9 @@ const [error, response] = await wompi.paymentSources.createPaymentSource({
   type: "CARD",
   token: token.id,
   acceptance_token: merchant.presigned_acceptance!.acceptance_token,
+  accept_personal_auth: merchant.presigned_personal_data_auth!.acceptance_token,
   customer_email: "buyer@example.com",
+  payment_description: "Suscripcion mensual",
 });
 if (error) throw error;
 
@@ -45,12 +47,16 @@ response.id; // numeric id — store this against your user
 
 ### Input
 
-| Field              | Type     | Notes                                              |
-| ------------------ | -------- | -------------------------------------------------- | ------------------------ |
-| `type`             | `"CARD"  | "NEQUI"`                                           | The token's source kind. |
-| `token`            | `string` | Output of `tokens.tokenizeCard` / `tokenizeNequi`. |
-| `acceptance_token` | `string` | Fresh value from the merchant resource.            |
-| `customer_email`   | `email`  | The customer this source belongs to.               |
+| Field                  | Type      | Notes                                                                                |
+| ---------------------- | --------- | ------------------------------------------------------------------------------------ |
+| `type`                 | `string`  | `"CARD"`, `"NEQUI"`, `"DAVIPLATA"` or `"BANCOLOMBIA_TRANSFER"`.                      |
+| `token`                | `string`  | Output of `tokens.tokenizeCard` / `tokenizeNequi`.                                   |
+| `acceptance_token`     | `string`  | `merchant.presigned_acceptance.acceptance_token`.                                    |
+| `accept_personal_auth` | `string?` | `merchant.presigned_personal_data_auth.acceptance_token` — the second consent.       |
+| `customer_email`       | `email`   | The customer this source belongs to.                                                 |
+| `payment_description`  | `string?` | Text the customer sees when they approve the source, e.g. in the Nequi push message. |
+
+Any other field Wompi documents also reaches the API — the SDK does not strip unknown keys from this payload.
 
 ## getPaymentSource(id)
 
@@ -61,20 +67,27 @@ const [error, response] = await wompi.paymentSources.getPaymentSource(12_345);
 if (error) throw error;
 
 response.id;
-response.status; // "AVAILABLE" | "PENDING"
-response.type; // "CARD" | "NEQUI"
+response.status; // "AVAILABLE", "PENDING" or "VOIDED"
+response.type; // "CARD", "NEQUI", "DAVIPLATA" or "BANCOLOMBIA_TRANSFER"
 ```
 
 ### Response
 
-| Field            | Type         | Notes                                                            |
-| ---------------- | ------------ | ---------------------------------------------------------------- | ------------------------------------------------ | ------------ |
-| `id`             | `number`     | Stable, persist this against your user.                          |
-| `status`         | `"AVAILABLE" | "PENDING"`                                                       | `PENDING` for Nequi until the customer approves. |
-| `type`           | `"CARD"      | "NEQUI"                                                          | undefined`                                       | Source kind. |
-| `token`          | `string?`    | The underlying token.                                            |
-| `customer_email` | `string?`    | Owning customer.                                                 |
-| `public_data`    | `object?`    | `&#123; type, phone_number? &#125;` — safe to surface in the UI. |
+| Field            | Type      | Notes                                                                          |
+| ---------------- | --------- | ------------------------------------------------------------------------------ |
+| `id`             | `number`  | Stable, persist this against your user.                                        |
+| `status`         | `string`  | `"AVAILABLE"`, `"PENDING"` (Nequi, until the customer approves) or `"VOIDED"`. |
+| `type`           | `string?` | `"CARD"`, `"NEQUI"`, `"DAVIPLATA"` or `"BANCOLOMBIA_TRANSFER"`.                |
+| `token`          | `string?` | The underlying token.                                                          |
+| `customer_email` | `string?` | Owning customer.                                                               |
+| `public_data`    | `object?` | `&#123; type, phone_number? &#125;` — safe to surface in the UI.               |
+
+:::note[Strings, not unions]
+`status` and `type` are typed as `string` on the response: Wompi adds source
+kinds and states over time, and a `200` must never fail validation. Import
+the `PaymentSourceType` and `PaymentSourceStatus` types from
+`@pulgueta/wompi/schemas` when you want to narrow to the known values.
+:::
 
 ## Charging a stored source
 
@@ -83,6 +96,7 @@ Drop the `id` into `createTransaction` as `payment_source_id`. Note the change i
 ```ts
 const [error, response] = await wompi.transactions.createTransaction({
   acceptance_token,
+  accept_personal_auth,
   amount_in_cents: 990_000,
   currency: "COP",
   signature,

--- a/apps/docs/content/docs/payment-sources.mdx
+++ b/apps/docs/content/docs/payment-sources.mdx
@@ -32,8 +32,10 @@ const [merchantError, merchant] = await wompi.merchants.getMerchant();
 if (merchantError) throw merchantError;
 
 const acceptanceToken = merchant.presigned_acceptance?.acceptance_token;
-const personalAuthToken = merchant.presigned_personal_data_auth?.acceptance_token;
-if (!acceptanceToken || !personalAuthToken) throw new Error("Merchant has no acceptance tokens");
+const personalAuthToken =
+  merchant.presigned_personal_data_auth?.acceptance_token;
+if (!acceptanceToken || !personalAuthToken)
+  throw new Error("Merchant has no acceptance tokens");
 
 // 3. Convert the card token into a long-lived payment source.
 const [error, response] = await wompi.paymentSources.createPaymentSource({

--- a/apps/docs/content/docs/payment-sources.mdx
+++ b/apps/docs/content/docs/payment-sources.mdx
@@ -31,12 +31,16 @@ if (tokenError) throw tokenError;
 const [merchantError, merchant] = await wompi.merchants.getMerchant();
 if (merchantError) throw merchantError;
 
+const acceptanceToken = merchant.presigned_acceptance?.acceptance_token;
+const personalAuthToken = merchant.presigned_personal_data_auth?.acceptance_token;
+if (!acceptanceToken || !personalAuthToken) throw new Error("Merchant has no acceptance tokens");
+
 // 3. Convert the card token into a long-lived payment source.
 const [error, response] = await wompi.paymentSources.createPaymentSource({
   type: "CARD",
   token: token.id,
-  acceptance_token: merchant.presigned_acceptance!.acceptance_token,
-  accept_personal_auth: merchant.presigned_personal_data_auth!.acceptance_token,
+  acceptance_token: acceptanceToken,
+  accept_personal_auth: personalAuthToken,
   customer_email: "buyer@example.com",
   payment_description: "Suscripcion mensual",
 });
@@ -52,7 +56,7 @@ response.id; // numeric id — store this against your user
 | `type`                 | `string`  | `"CARD"`, `"NEQUI"`, `"DAVIPLATA"` or `"BANCOLOMBIA_TRANSFER"`.                      |
 | `token`                | `string`  | Output of `tokens.tokenizeCard` / `tokenizeNequi`.                                   |
 | `acceptance_token`     | `string`  | `merchant.presigned_acceptance.acceptance_token`.                                    |
-| `accept_personal_auth` | `string?` | `merchant.presigned_personal_data_auth.acceptance_token` — the second consent.       |
+| `accept_personal_auth` | `string`  | `merchant.presigned_personal_data_auth.acceptance_token` — the second consent.       |
 | `customer_email`       | `email`   | The customer this source belongs to.                                                 |
 | `payment_description`  | `string?` | Text the customer sees when they approve the source, e.g. in the Nequi push message. |
 

--- a/apps/docs/content/docs/quickstart.mdx
+++ b/apps/docs/content/docs/quickstart.mdx
@@ -30,10 +30,11 @@ const [merchantError, merchant] = await wompi.merchants.getMerchant();
 if (merchantError) throw merchantError;
 
 const acceptanceToken = merchant.presigned_acceptance?.acceptance_token;
-if (!acceptanceToken) throw new Error("Merchant has no acceptance token");
-
 const personalAuthToken =
   merchant.presigned_personal_data_auth?.acceptance_token;
+if (!acceptanceToken || !personalAuthToken) {
+  throw new Error("Merchant has no acceptance tokens");
+}
 ```
 
 ## 3. Tokenize the card

--- a/apps/docs/content/docs/quickstart.mdx
+++ b/apps/docs/content/docs/quickstart.mdx
@@ -21,9 +21,9 @@ export const wompi = new WompiClient({
 });
 ```
 
-## 2. Fetch the acceptance token
+## 2. Fetch the acceptance tokens
 
-Every transaction must include the merchant's presigned acceptance token — proof that the customer accepted the merchant's policies. Fetch it from the merchant endpoint.
+Every transaction must include two presigned tokens — proof that the customer accepted the merchant's end-user policy and the personal-data authorization. Fetch both from the merchant endpoint.
 
 ```ts
 const [merchantError, merchant] = await wompi.merchants.getMerchant();
@@ -31,6 +31,9 @@ if (merchantError) throw merchantError;
 
 const acceptanceToken = merchant.presigned_acceptance?.acceptance_token;
 if (!acceptanceToken) throw new Error("Merchant has no acceptance token");
+
+const personalAuthToken =
+  merchant.presigned_personal_data_auth?.acceptance_token;
 ```
 
 ## 3. Tokenize the card
@@ -77,12 +80,13 @@ Read [Integrity signature](/docs/integrity-signature) for the full rules — inc
 
 ## 5. Create the transaction
 
-Stitch it together: the acceptance token, the signed amount, the card token, the reference and a customer email. The response status starts at `PENDING` — poll `getTransaction(id)` until it resolves.
+Stitch it together: the two acceptance tokens, the signed amount, the card token, the reference and a customer email. The response status starts at `PENDING` — poll `getTransaction(id)` until it resolves.
 
 ```ts
 const [transactionError, transaction] =
   await wompi.transactions.createTransaction({
     acceptance_token: acceptanceToken,
+    accept_personal_auth: personalAuthToken,
     amount_in_cents: amountInCents,
     currency: "COP",
     signature,

--- a/apps/docs/content/docs/transactions.mdx
+++ b/apps/docs/content/docs/transactions.mdx
@@ -25,9 +25,13 @@ Create a new transaction. You must include at least one of `payment_method` or `
 const [merchantError, merchant] = await wompi.merchants.getMerchant();
 if (merchantError) throw merchantError;
 
+const acceptanceToken = merchant.presigned_acceptance?.acceptance_token;
+const personalAuthToken = merchant.presigned_personal_data_auth?.acceptance_token;
+if (!acceptanceToken || !personalAuthToken) throw new Error("Merchant has no acceptance tokens");
+
 const [error, response] = await wompi.transactions.createTransaction({
-  acceptance_token: merchant.presigned_acceptance!.acceptance_token,
-  accept_personal_auth: merchant.presigned_personal_data_auth!.acceptance_token,
+  acceptance_token: acceptanceToken,
+  accept_personal_auth: personalAuthToken,
   amount_in_cents: 2_490_000,
   currency: "COP",
   signature,
@@ -56,7 +60,7 @@ permalinks before you charge.
 | Field                   | Type       | Notes                                                                                                        |
 | ----------------------- | ---------- | ------------------------------------------------------------------------------------------------------------ |
 | `acceptance_token`      | `string`   | `merchant.presigned_acceptance.acceptance_token`.                                                            |
-| `accept_personal_auth`  | `string?`  | `merchant.presigned_personal_data_auth.acceptance_token`.                                                    |
+| `accept_personal_auth`  | `string`   | `merchant.presigned_personal_data_auth.acceptance_token`.                                                    |
 | `amount_in_cents`       | `integer`  | 1 – 1 000 000 000 000.                                                                                       |
 | `currency`              | `"COP"`    | Only value Wompi accepts.                                                                                    |
 | `signature`             | `string`   | SHA-256 hex digest.                                                                                          |
@@ -80,9 +84,10 @@ Any other field Wompi documents also reaches the API — the SDK does not strip 
 
 ```ts
 // Re-charge a stored payment source — no card token, no signature handshake.
+// `acceptanceToken` / `personalAuthToken` come from the merchant, as above.
 const [error, response] = await wompi.transactions.createTransaction({
-  acceptance_token: merchant.presigned_acceptance!.acceptance_token,
-  accept_personal_auth: merchant.presigned_personal_data_auth!.acceptance_token,
+  acceptance_token: acceptanceToken,
+  accept_personal_auth: personalAuthToken,
   amount_in_cents: 1_990_000,
   currency: "COP",
   signature,

--- a/apps/docs/content/docs/transactions.mdx
+++ b/apps/docs/content/docs/transactions.mdx
@@ -26,8 +26,10 @@ const [merchantError, merchant] = await wompi.merchants.getMerchant();
 if (merchantError) throw merchantError;
 
 const acceptanceToken = merchant.presigned_acceptance?.acceptance_token;
-const personalAuthToken = merchant.presigned_personal_data_auth?.acceptance_token;
-if (!acceptanceToken || !personalAuthToken) throw new Error("Merchant has no acceptance tokens");
+const personalAuthToken =
+  merchant.presigned_personal_data_auth?.acceptance_token;
+if (!acceptanceToken || !personalAuthToken)
+  throw new Error("Merchant has no acceptance tokens");
 
 const [error, response] = await wompi.transactions.createTransaction({
   acceptance_token: acceptanceToken,

--- a/apps/docs/content/docs/transactions.mdx
+++ b/apps/docs/content/docs/transactions.mdx
@@ -19,11 +19,15 @@ The transactions resource handles the actual money movement. There are four meth
 
 ## createTransaction(input)
 
-Create a new transaction. You must include exactly one of `payment_method` or `payment_source_id` — the SDK validates the constraint locally before sending.
+Create a new transaction. You must include at least one of `payment_method` or `payment_source_id` — the SDK validates the constraint locally before sending. Send both to charge a stored card source, which needs `payment_method.installments`.
 
 ```ts
+const [merchantError, merchant] = await wompi.merchants.getMerchant();
+if (merchantError) throw merchantError;
+
 const [error, response] = await wompi.transactions.createTransaction({
-  acceptance_token: acceptance.acceptance_token,
+  acceptance_token: merchant.presigned_acceptance!.acceptance_token,
+  accept_personal_auth: merchant.presigned_personal_data_auth!.acceptance_token,
   amount_in_cents: 2_490_000,
   currency: "COP",
   signature,
@@ -38,35 +42,54 @@ const [error, response] = await wompi.transactions.createTransaction({
 `@pulgueta/wompi/server` — see [Integrity signature](/docs/integrity-signature).
 :::
 
+:::note[Two acceptance tokens]
+Wompi asks the customer for two consents: the end-user policy
+(`acceptance_token`) and the personal-data authorization
+(`accept_personal_auth`). Both come from
+[`merchants.getMerchant()`](/docs/merchants) — `presigned_acceptance` and
+`presigned_personal_data_auth` — and both are short-lived. Show the two
+permalinks before you charge.
+:::
+
 ### Input fields
 
-| Field               | Type       | Notes                                              |
-| ------------------- | ---------- | -------------------------------------------------- |
-| `acceptance_token`  | `string`   | From `merchants.getMerchant()`.                    |
-| `amount_in_cents`   | `integer`  | 1 – 1 000 000 000 000.                             |
-| `currency`          | `"COP"`    | Only value Wompi accepts.                          |
-| `signature`         | `string`   | SHA-256 hex digest.                                |
-| `customer_email`    | `email`    | Receipts go here.                                  |
-| `reference`         | `string`   | Your own merchant reference.                       |
-| `payment_method`    | `object?`  | Exclusive with `payment_source_id`.                |
-| `payment_source_id` | `integer?` | Exclusive with `payment_method`.                   |
-| `redirect_url`      | `url?`     | Where to send the customer after off-site payment. |
-| `expiration_time`   | `string?`  | ISO-8601; must also be hashed in the signature.    |
-| `customer_data`     | `object?`  | `full_name`, `legal_id`, …                         |
-| `shipping_address`  | `object?`  | For physical-goods checkouts.                      |
+| Field                   | Type       | Notes                                                                                                        |
+| ----------------------- | ---------- | ------------------------------------------------------------------------------------------------------------ |
+| `acceptance_token`      | `string`   | `merchant.presigned_acceptance.acceptance_token`.                                                            |
+| `accept_personal_auth`  | `string?`  | `merchant.presigned_personal_data_auth.acceptance_token`.                                                    |
+| `amount_in_cents`       | `integer`  | 1 – 1 000 000 000 000.                                                                                       |
+| `currency`              | `"COP"`    | Only value Wompi accepts.                                                                                    |
+| `signature`             | `string`   | SHA-256 hex digest.                                                                                          |
+| `customer_email`        | `email`    | Receipts go here.                                                                                            |
+| `reference`             | `string`   | Your own merchant reference.                                                                                 |
+| `payment_method`        | `object?`  | At least one of `payment_method` / `payment_source_id`.                                                      |
+| `payment_source_id`     | `integer?` | At least one of `payment_method` / `payment_source_id`.                                                      |
+| `redirect_url`          | `url?`     | Where to send the customer after off-site payment.                                                           |
+| `expiration_time`       | `string?`  | ISO-8601; must also be hashed in the signature.                                                              |
+| `customer_data`         | `object?`  | `full_name`, `legal_id`, …                                                                                   |
+| `shipping_address`      | `object?`  | For physical-goods checkouts.                                                                                |
+| `taxes`                 | `array?`   | `&#123; type, amount_in_cents &#125;` or `&#123; type, percentage &#125;`; `type` is `VAT` or `CONSUMPTION`. |
+| `ip`                    | `string?`  | Buyer IP address, for risk analysis.                                                                         |
+| `recurrent`             | `boolean?` | Marks the charge as recurring.                                                                               |
+| `parent_transaction_id` | `string?`  | Id of the first transaction of a recurring series.                                                           |
+| `payment_method_type`   | `string?`  | Method type, when Wompi cannot infer it from `payment_method`.                                               |
+
+Any other field Wompi documents also reaches the API — the SDK does not strip unknown keys from this payload.
 
 ### Create with a stored payment source
 
 ```ts
 // Re-charge a stored payment source — no card token, no signature handshake.
 const [error, response] = await wompi.transactions.createTransaction({
-  acceptance_token: acceptance.acceptance_token,
+  acceptance_token: merchant.presigned_acceptance!.acceptance_token,
+  accept_personal_auth: merchant.presigned_personal_data_auth!.acceptance_token,
   amount_in_cents: 1_990_000,
   currency: "COP",
   signature,
   customer_email: "buyer@example.com",
   reference: `recur-${Date.now()}`,
   payment_source_id: 12_345, // requires the private key
+  payment_method: { installments: 1 }, // required for a stored CARD source
 });
 ```
 

--- a/apps/example/README.md
+++ b/apps/example/README.md
@@ -27,7 +27,7 @@ npx convex env set AI_GATEWAY_CHAT_MODEL zai/glm-5.2                    # option
 npx convex env set AI_GATEWAY_EMBEDDING_MODEL openai/text-embedding-3-small  # optional, this is the default
 ```
 
-Both model ids need the provider prefix — an id without it fails against the AI Gateway. Changing `AI_GATEWAY_EMBEDDING_MODEL` (or its dimension) invalidates the index: re-ingest the corpus after the change.
+Both model ids need the provider prefix — an id without it fails against the AI Gateway. The RAG index is fixed at 1,536 dimensions (`embeddingDimension` in `convex/rag.ts`), so `AI_GATEWAY_EMBEDDING_MODEL` must be a 1,536-dimension model — `openai/text-embedding-3-small` (default) or `openai/text-embedding-ada-002`. A model with another output size needs a matching `embeddingDimension` change. Either change invalidates the index: re-ingest the corpus afterwards.
 
 Install dependencies from the monorepo root, then provision and run the example:
 

--- a/apps/example/README.md
+++ b/apps/example/README.md
@@ -23,7 +23,11 @@ The assistant's Vercel AI Gateway key lives on the Convex deployment:
 ```bash
 cd apps/example
 npx convex env set AI_GATEWAY_API_KEY vck_...
+npx convex env set AI_GATEWAY_CHAT_MODEL zai/glm-5.2                    # optional, this is the default
+npx convex env set AI_GATEWAY_EMBEDDING_MODEL openai/text-embedding-3-small  # optional, this is the default
 ```
+
+Both model ids need the provider prefix — an id without it fails against the AI Gateway. Changing `AI_GATEWAY_EMBEDDING_MODEL` (or its dimension) invalidates the index: re-ingest the corpus after the change.
 
 Install dependencies from the monorepo root, then provision and run the example:
 
@@ -43,6 +47,12 @@ pnpm ingest-wompi-docs  # 60 official docs.wompi.co pages
 
 `ingest-wompi-docs` fetches the official pages as markdown, so it requires
 network access and the local `curl.md` helper on `PATH`.
+
+Each document is tagged with a section (`getting-started`, `checkout`, `events`, `payouts`, `plugins`, `reports`, `sdk`) so the assistant can narrow a search. A corpus ingested before the tag existed has no sections — re-ingest to get the filter.
+
+### `stopWhen` trap
+
+`@convex-dev/agent` stops after the first tool call unless the agent sets `stopWhen: stepCountIs(n)`. Without it the run ends with `finishReason: "tool-calls"`, no answer is written, and the UI shows empty bubbles. See `stopWhen: stepCountIs(8)` in `convex/chat.ts`.
 
 ## Webhooks
 

--- a/apps/example/convex/chat.ts
+++ b/apps/example/convex/chat.ts
@@ -18,8 +18,10 @@ import { internalAction, mutation, query } from "./_generated/server";
 import type { QueryCtx, MutationCtx } from "./_generated/server";
 import type { Id } from "./_generated/dataModel";
 import { components, internal } from "./_generated/api";
-import { rag, WOMPI_DOCS_NAMESPACE } from "./rag";
+import { DOC_SECTIONS, rag, WOMPI_DOCS_NAMESPACE } from "./rag";
+import type { DocSection } from "./rag";
 
+const CHAT_MODEL = process.env.AI_GATEWAY_CHAT_MODEL ?? "zai/glm-5.2";
 const DEMO_USER_ID = "panabarbero-demo";
 const DEFAULT_THREAD_TITLE = "Asistente Wompi";
 const AGENT_NAME = DEFAULT_THREAD_TITLE;
@@ -178,8 +180,8 @@ const SDK_TOPIC_ALIASES: Record<string, string> = {
 
 const searchWompiDocs = createTool({
   description:
-    "Busca en la documentación oficial de Wompi y del SDK @pulgueta/wompi. Úsala SIEMPRE antes de responder cualquier pregunta.",
-  inputSchema: jsonSchema<{ query: string }>({
+    "Busca en la documentación oficial de Wompi y del SDK @pulgueta/wompi. Úsala SIEMPRE antes de responder cualquier pregunta. Puedes acotar la búsqueda a una sección con el parámetro section.",
+  inputSchema: jsonSchema<{ query: string; section?: DocSection }>({
     type: "object",
     properties: {
       query: {
@@ -187,15 +189,24 @@ const searchWompiDocs = createTool({
         description:
           "Consulta en lenguaje natural sobre Wompi, sus APIs o el SDK",
       },
+      section: {
+        type: "string",
+        enum: [...DOC_SECTIONS],
+        description:
+          "Sección opcional para acotar la búsqueda: getting-started (llaves, ambientes, transacciones, errores), checkout (widget, datos de prueba), events (eventos y seguimiento), payouts (Pagos a Terceros y BRE-B), plugins (WooCommerce, Shopify, VTEX…), reports (reportes), sdk (docs del SDK @pulgueta/wompi)",
+      },
     },
     required: ["query"],
     additionalProperties: false,
   }),
-  execute: async (ctx, { query }) => {
+  execute: async (ctx, { query, section }) => {
     const { results, entries } = await rag.search(ctx, {
       namespace: WOMPI_DOCS_NAMESPACE,
       query,
       limit: 5,
+      ...(section !== undefined
+        ? { filters: [{ name: "section" as const, value: section }] }
+        : {}),
     });
     if (results.length === 0) {
       return "No se encontraron documentos en el índice. (¿Ya se ejecutó `pnpm ingest-docs` con OPENAI_API_KEY configurada?)";
@@ -284,7 +295,7 @@ const getSdkExample = createTool({
 
 export const wompiAgent = new Agent(components.agent, {
   name: AGENT_NAME,
-  languageModel: gateway("zai/glm-5.2"),
+  languageModel: gateway(CHAT_MODEL),
   instructions: `Eres el "Asistente Wompi" del demo PanaBarbero: un asistente de integración de pagos Wompi (Colombia) construido con el SDK @pulgueta/wompi.
 
 Reglas:

--- a/apps/example/convex/rag.ts
+++ b/apps/example/convex/rag.ts
@@ -10,9 +10,28 @@ import { components, internal } from "./_generated/api";
 
 export const WOMPI_DOCS_NAMESPACE = "wompi-docs";
 
-export const rag = new RAG(components.rag, {
-  textEmbeddingModel: gateway.embedding("openai/text-embedding-3-small"),
+// The id must keep the provider prefix; "text-embedding-3-small" alone fails
+// against the AI Gateway.
+const EMBEDDING_MODEL =
+  process.env.AI_GATEWAY_EMBEDDING_MODEL ?? "openai/text-embedding-3-small";
+
+/** Sections used to narrow the docs search. Assigned by the ingest scripts. */
+export const DOC_SECTIONS = [
+  "getting-started",
+  "checkout",
+  "events",
+  "payouts",
+  "plugins",
+  "reports",
+  "sdk",
+] as const;
+
+export type DocSection = (typeof DOC_SECTIONS)[number];
+
+export const rag = new RAG<{ section: string }>(components.rag, {
+  textEmbeddingModel: gateway.embedding(EMBEDDING_MODEL),
   embeddingDimension: 1536,
+  filterNames: ["section"],
 });
 
 /**
@@ -28,6 +47,7 @@ export const ingestDoc = internalAction({
     title: v.string(),
     source: v.string(),
     url: v.optional(v.string()),
+    section: v.optional(v.string()),
     content: v.string(),
   },
   returns: v.null(),
@@ -49,7 +69,11 @@ export const ingestDoc = internalAction({
       metadata: {
         title: args.title,
         ...(args.url !== undefined ? { url: args.url } : {}),
+        ...(args.section !== undefined ? { section: args.section } : {}),
       },
+      ...(args.section !== undefined
+        ? { filterValues: [{ name: "section" as const, value: args.section }] }
+        : {}),
       text: args.content,
     });
     return null;

--- a/apps/example/convex/rag.ts
+++ b/apps/example/convex/rag.ts
@@ -11,7 +11,8 @@ import { components, internal } from "./_generated/api";
 export const WOMPI_DOCS_NAMESPACE = "wompi-docs";
 
 // The id must keep the provider prefix; "text-embedding-3-small" alone fails
-// against the AI Gateway.
+// against the AI Gateway. The model must output 1,536 dimensions to match
+// `embeddingDimension` below (see README).
 const EMBEDDING_MODEL =
   process.env.AI_GATEWAY_EMBEDDING_MODEL ?? "openai/text-embedding-3-small";
 

--- a/apps/example/scripts/ingest-docs.mjs
+++ b/apps/example/scripts/ingest-docs.mjs
@@ -57,6 +57,8 @@ for (const file of files) {
   const payload = {
     title: titleOf(frontmatter, trimmed, source),
     source,
+    // Repository docs and READMEs are the SDK section of the corpus.
+    section: "sdk",
     content: trimmed,
   };
 

--- a/apps/example/scripts/ingest-wompi-docs.mjs
+++ b/apps/example/scripts/ingest-wompi-docs.mjs
@@ -109,6 +109,48 @@ export const WOMPI_DOCS = [
   ["WompiJs (deprecada)", "js"],
 ];
 
+// Sections mirror DOC_SECTIONS in convex/rag.ts and feed the `section` filter
+// of the searchWompiDocs tool.
+
+// "API Pagos a terceros: …" pages whose slug has no payouts marker.
+const PAYOUT_SLUGS = new Set([
+  "crea-tu-primer-lote",
+  "consultas-y-operaciones",
+]);
+const PLUGIN_SLUGS = new Set([
+  "woocommerce-wordpress-plugin",
+  "wompi-shopify-plugin",
+  "jumpseller-plugin",
+  "magento-plugin",
+  "prestashop-plugin",
+  "wompi-vtex",
+]);
+const EVENT_SLUGS = new Set([
+  "eventos",
+  "seguimiento-de-transacciones",
+  "reintento-de-pago",
+]);
+const CHECKOUT_SLUGS = new Set([
+  "widget-checkout-web",
+  "datos-de-prueba-en-sandbox",
+  "ambientes-y-llaves",
+]);
+
+export const sectionFor = (slug) => {
+  if (
+    slug.includes("pagos-a-terceros") ||
+    slug.includes("breb") ||
+    PAYOUT_SLUGS.has(slug)
+  ) {
+    return "payouts";
+  }
+  if (PLUGIN_SLUGS.has(slug)) return "plugins";
+  if (slug.startsWith("reporte-")) return "reports";
+  if (EVENT_SLUGS.has(slug)) return "events";
+  if (CHECKOUT_SLUGS.has(slug)) return "checkout";
+  return "getting-started";
+};
+
 const fetchMarkdown = (slug) => {
   const cached = join(cacheDir, `${slug}.md`);
   if (existsSync(cached)) {
@@ -145,6 +187,7 @@ for (const [title, slug] of selected) {
         title,
         source: `wompi-docs/${slug}`,
         url: `${BASE}/${slug}/`,
+        section: sectionFor(slug),
         content,
       };
       console.log(`Ingesting wompi-docs/${slug} (${content.length} chars)…`);

--- a/packages/convex-component/PUBLISHING.md
+++ b/packages/convex-component/PUBLISHING.md
@@ -1,84 +1,31 @@
 # Publishing
 
-In order for other people to install and use this component, you can publish the
-package to npm.
+`@pulgueta/wompi-convex` is released from the monorepo by the changesets
+GitHub Action, never by hand.
 
-You will first need to have an npmjs account with permissions to push to your
-package name.
+1. Add a changeset with your change: `pnpm changeset` (from the repo root).
+2. Merge to `main`. The Action opens (or updates) the "chore(release):
+   version packages" pull request.
+3. Merge that pull request. The Action runs `pnpm release`
+   (`turbo build && changeset publish`) and publishes to npm.
 
-If this is your first time, here are the recommended steps:
+## Do not `npm publish` / `npm pack`
 
-1. Ensure the package.json "name" matches what you want it to be called. It
-   should either be like `my-package` or `@my-org/my-package`. If it's the
-   latter, ensure you have an npmjs account with permissions to push to
-   `my-org`.
-2. `npm login` to login to npmjs.
-3. `npm run clean` to clean your `/dist` directory.
-4. `npm ci` to install the dependencies with the versions specified in
-   `package-lock.json`.
-5. `npm run build` to build the package fresh.
-6. (Optional) `npm run typecheck` to typecheck the package.
-7. (Optional) `npm run lint` to lint the package.
-8. (Optional) `npm run test` to test the package.
-9. (Optional) `npm pack` will create a .tgz file of the package. You can then
-   try installing it in another project with
-   `npm install ./path/to/your-package.tgz` to sanity check that it works as
-   expected. You can remove the .tgz file after.
-10. `npm publish --access public` to publish the package to npm.
-11. `git tag v0.1.0` to tag the new version.
-12. `git push --follow-tags` to push the tags to the repository. This way, other
-    contributors can always see what code was published with each version.
-    Running `npm version ...` will create these tags and commits automatically.
+This package depends on `@pulgueta/wompi` with the `workspace:^` protocol.
+Only pnpm rewrites that specifier to a real version range when it packs the
+tarball. A tarball produced with `npm publish` or `npm pack` still contains
+`workspace:^`, and every `npm install` of that version fails with
+`EUNSUPPORTEDPROTOCOL` — this happened with `0.2.0`.
 
-After the initial publish, you can use the release scripts documented below,
-which will do steps 3-12 automatically (except the sanity check in step 9).
-
-## Package scripts for releasing
-
-In package.json, there are some scripts that are useful for doing releases.
-
-- `preversion` will run the tests and typecheck the code before marking a new
-  version.
-- `version` will open the changelog in vim and then save it before committing
-  the new version.
-- `prepublishOnly` will make a clean build of the package before publishing.
-
-These are not required and can be modified or removed if desired. They will all
-be run automatically when using one of the deployment commands.
-
-## Deploying a new alpha version
+CI packs both publishable packages with `pnpm pack` and fails when a manifest
+still contains `workspace:`. To sanity-check a build locally:
 
 ```sh
-npm run alpha
+pnpm --filter ./packages/convex-component pack --pack-destination /tmp/packs
+tar -xOf /tmp/packs/pulgueta-wompi-convex-*.tgz package/package.json | grep -n '"@pulgueta/wompi"'
 ```
 
-This will create a prerelease version with an `@alpha` tag. It will then publish
-the package to npm and push the code and new tag. Users can install the package
-with `npm install @your-package@alpha`.
+The line must show a version range (for example `"^3.3.0"`), not `workspace:^`.
 
-## Deploying a new release version
-
-```sh
-npm run release
-```
-
-This will create a patch version and publish as `latest`. It will then publish
-the package to npm and push the code and new tag. To publish a new minor or
-major version, you can run the commands manually:
-
-```sh
-npm version minor # or major
-npm publish
-git push --follow-tags
-```
-
-## Building a one-off package
-
-```sh
-npm run clean
-npm run build
-npm pack
-```
-
-You can then provide the .tgz file to others to install via
-`npm install ./path/to/your-package.tgz`.
+`build` always removes `dist` and the incremental `tsbuildinfo` first, so a
+stale local build can never leak missing declaration files into a release.

--- a/packages/convex-component/README.md
+++ b/packages/convex-component/README.md
@@ -134,9 +134,13 @@ const buy = async () => {
 ```
 
 The action creates a pending `payments` row with a unique reference, signs the
-amount with your integrity key, and returns the redirect URL. Wompi sends the
-customer back with `?id=<transactionId>` — confirm it for instant feedback
-(webhooks resolve it anyway):
+amount with your integrity key, and returns the redirect URL. The prebuilt
+action only takes a `productKey`: the amount always comes from your catalog,
+never from the browser. For custom amounts, descriptions or metadata call
+`wompi.checkout(ctx, { redirectUrl, amountInCents, metadata })` from your own
+server function, where you control the inputs. Wompi sends the customer back
+with `?id=<transactionId>` — confirm it for instant feedback (webhooks resolve
+it anyway):
 
 ```tsx
 const confirm = useAction(api.wompi.confirmTransaction);
@@ -149,7 +153,11 @@ useEffect(() => {
 
 `confirmTransaction` fetches the transaction from the Wompi API and runs it
 through the same idempotent state machine webhooks use — safe to call any
-number of times, from anywhere.
+number of times, from anywhere. The prebuilt action requires a signed-in user
+and only returns the payment when it belongs to that user; for anyone else it
+returns the bare outcome code. Wompi lets a payer retry a declined Web
+Checkout attempt under the same reference: a later `APPROVED` transaction
+supersedes the declined one (`supersededTransactionIds` keeps the history).
 
 ## Subscriptions
 
@@ -158,9 +166,8 @@ Tokenize in the browser (public key, PCI-friendly), subscribe in one action:
 ```tsx
 import { useWompiTokenizer } from "@pulgueta/wompi-convex/react";
 
-const { tokenizeCard, acceptancePermalink, ready } = useWompiTokenizer(
-  api.wompi.getConfig,
-);
+const { tokenizeCard, acceptancePermalink, personalDataAuthPermalink, ready } =
+  useWompiTokenizer(api.wompi.getConfig);
 const subscribe = useAction(api.wompi.subscribe);
 
 const onSubmit = async (card) => {
@@ -173,11 +180,16 @@ const onSubmit = async (card) => {
 };
 ```
 
-`subscribe` creates the Wompi payment source (with a fresh merchant acceptance
-token), inserts the subscription, and charges the first period — polling
-briefly so the common sandbox/production case resolves before the action
-returns. Trials skip the initial charge and convert automatically when they
-end.
+`subscribe` creates the Wompi payment source, inserts the subscription, and
+charges the first period — polling briefly so the common sandbox/production
+case resolves before the action returns. Trials skip the initial charge and
+convert automatically when they end. Wompi requires two acceptance tokens on
+every payment source and transaction (terms of use and personal-data
+authorization); `subscribe` fetches both from the merchant and sends them, so
+show the user both `acceptancePermalink` and `personalDataAuthPermalink` next
+to the card form. Calling `subscribe` twice while the first charge is in
+flight (double submit, action retry) reuses the same pending payment and
+reference — it never mints a second charge.
 
 Subscription state is a reactive query:
 
@@ -211,14 +223,22 @@ Wompi has no subscription engine, so the component is one:
 3. Charges run against the saved payment source
    (`payment_source_id` + `payment_method.installments`). Results — from the
    charge response, a webhook, or redirect confirmation — all flow through one
-   idempotent `applyTransaction` state machine.
+   idempotent `applyTransaction` state machine. A charge whose response never
+   arrives (timeout, 5xx, network) is left pending rather than marked failed:
+   the next claim reuses the same reference, Wompi rejects the duplicate, and
+   the existing transaction is reconciled — never a second charge. Only a
+   rejected request (4xx) finalizes an attempt as `error`.
 4. Failed renewals walk a dunning ladder (default retries at +1d, +2d, +4d;
    `past_due` keeps access as grace). Exhausted dunning marks the subscription
    `unpaid` (or `canceled`, your choice). Price snapshots are taken at
    subscribe time; catalog price changes only affect new subscribers. Plan
    changes apply at the next renewal, without proration.
 5. The same cron sweeps stale pending payments: ones with a transaction id are
-   reconciled against the API; abandoned checkouts expire after ~26h.
+   reconciled against the API; ones without are looked up by reference
+   (server-side charges every run, checkouts once before expiring) so a
+   payment that reached Wompi without a webhook is still recorded; abandoned
+   checkouts expire after ~26h. A late `APPROVED` still reopens an expired or
+   declined row.
 
 Defaults are tunable:
 
@@ -239,8 +259,13 @@ new Wompi(components.wompi, {
 });
 ```
 
-Callbacks fire exactly once per state change, whether the change arrived via
-webhook, cron, or confirmation.
+Callbacks fire once per state change, whether the change arrived via webhook,
+cron, or confirmation: redeliveries and repeated confirmations are no-ops.
+Payment callbacks run after the component state commits, so a crash between
+the two can skip a callback (at-most-once) — a webhook retry reprocesses the
+delivery when the state was not applied, but not when only the callback was
+lost. Reconcile from `payments`/`subscriptions` if your side effects must be
+exact.
 
 ## Dispersions (Pagos a Terceros)
 
@@ -370,7 +395,10 @@ back and Wompi's retry can safely replay it; completed redeliveries are no-ops.
   row, so a transaction crafted against your public key with a reused
   reference and a 1-cent amount grants nothing.
 - Component functions are only callable from your server functions; everything
-  in `api()` resolves identity through `getUserInfo`, never from client args.
+  in `api()` that touches user data resolves identity through `getUserInfo`,
+  never from client args. `checkout` only accepts a catalog `productKey`
+  (amounts and metadata are never client-supplied), and `confirmTransaction`
+  redacts payments that belong to another user.
 
 ## Tables
 
@@ -378,7 +406,7 @@ back and Wompi's retry can safely replay it; completed redeliveries are no-ops.
 | --- | --- |
 | `customers` | Your users in the billing domain (`userId` ↔ email). |
 | `products` | The catalog you define (`one_time` or `subscription` with interval/trial). |
-| `paymentSources` | Saved Wompi payment sources (brand/last four for display). |
+| `paymentSources` | Saved Wompi payment sources (brand/last four for display, `termsAcceptedAt`). |
 | `subscriptions` | The state machine: status, period, `nextChargeAt`, dunning counters. |
 | `payments` | One row per charge attempt, keyed by unique Wompi reference. |
 | `dispersions` | Payout batches (Pagos a Terceros), keyed by Wompi payout id. |

--- a/packages/convex-component/README.md
+++ b/packages/convex-component/README.md
@@ -227,7 +227,8 @@ Wompi has no subscription engine, so the component is one:
    arrives (timeout, 5xx, network) is left pending rather than marked failed:
    the next claim reuses the same reference, Wompi rejects the duplicate, and
    the existing transaction is reconciled — never a second charge. Only a
-   rejected request (4xx) finalizes an attempt as `error`.
+   request Wompi actually rejected (validation, not found, other 4xx except
+   408 and 429) finalizes an attempt as `error`.
 4. Failed renewals walk a dunning ladder (default retries at +1d, +2d, +4d;
    `past_due` keeps access as grace). Exhausted dunning marks the subscription
    `unpaid` (or `canceled`, your choice). Price snapshots are taken at
@@ -266,6 +267,12 @@ the two can skip a callback (at-most-once) — a webhook retry reprocesses the
 delivery when the state was not applied, but not when only the callback was
 lost. Reconcile from `payments`/`subscriptions` if your side effects must be
 exact.
+
+`registerRoutes(http, { onEvent })` is different: it runs for every verified
+delivery that was not already applied. Two deliveries of the same event that
+overlap before the first outcome is stored, or a redelivery after a crash
+mid-apply, both reach `onEvent` — make it idempotent (key on
+`event.signature.checksum` or the transaction id).
 
 ## Dispersions (Pagos a Terceros)
 

--- a/packages/convex-component/package.json
+++ b/packages/convex-component/package.json
@@ -19,14 +19,17 @@
   ],
   "type": "module",
   "scripts": {
-    "build": "tsc --project ./tsconfig.build.json",
-    "build:clean": "rm -rf dist *.tsbuildinfo && pnpm run build",
+    "build": "rm -rf dist *.tsbuildinfo && tsc --project ./tsconfig.build.json",
+    "build:clean": "pnpm run build",
     "typecheck": "tsc --noEmit",
     "lint": "eslint .",
     "test": "vitest run --typecheck",
     "test:watch": "vitest --typecheck --clearScreen false",
     "test:debug": "vitest --inspect-brk --no-file-parallelism",
     "test:coverage": "vitest run --coverage --coverage.reporter=text"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "files": [
     "dist",
@@ -65,6 +68,11 @@
   "peerDependencies": {
     "convex": "^1.36.1",
     "react": "^18.3.1 || ^19.0.0"
+  },
+  "peerDependenciesMeta": {
+    "react": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@convex-dev/eslint-plugin": "^2.0.0",

--- a/packages/convex-component/src/client/billing.test.ts
+++ b/packages/convex-component/src/client/billing.test.ts
@@ -275,6 +275,95 @@ describe("renewal charge idempotency", () => {
     expect(sub?.failedAttempts).toBe(1);
   });
 
+  test("a duplicate-reference rejection whose lookup fails leaves the payment pending", async () => {
+    const t = initConvexTest();
+    const subscription = await dueRenewal(t);
+    const wompi = makeWompi();
+
+    let lookups = 0;
+    vi.stubGlobal(
+      "fetch",
+      routeFetch([
+        { method: "GET", path: /\/merchants\//, respond: () => merchant() },
+        {
+          method: "POST",
+          path: /\/transactions$/,
+          respond: () => json(REFERENCE_USED, 422),
+        },
+        {
+          method: "GET",
+          path: /\/transactions\?reference=/,
+          respond: () => {
+            lookups++;
+            return json({ error: { type: "INTERNAL", reason: "try later" } }, 503);
+          },
+        },
+      ]),
+    );
+
+    // Wompi holds a transaction for this reference (it rejected the
+    // duplicate) but cannot list it right now: the row must stay pending so
+    // the sweep reconciles it later, not be finalized as `error`.
+    const summary = await t.action(async (ctx) => await wompi.processBilling(ctx));
+    expect(summary.stillPending).toBe(1);
+    expect(summary.declined).toBe(0);
+    expect(lookups).toBeGreaterThanOrEqual(1);
+
+    const payments = await paymentsOf(t, subscription._id);
+    const renewal = payments.find((p) => p.periodStart);
+    expect(renewal?.status).toBe("pending");
+    const sub = await subscriptionOf(t, subscription._id);
+    expect(sub?.status).toBe("active");
+    expect(sub?.failedAttempts).toBe(0);
+  });
+
+  test("a newer terminal transaction outranks an older pending one for the same reference", async () => {
+    const t = initConvexTest();
+    const subscription = await dueRenewal(t);
+    const wompi = makeWompi();
+
+    let reference = "";
+    vi.stubGlobal(
+      "fetch",
+      routeFetch([
+        { method: "GET", path: /\/merchants\//, respond: () => merchant() },
+        {
+          method: "POST",
+          path: /\/transactions$/,
+          respond: (init) => {
+            reference = (JSON.parse(String(init?.body)) as { reference: string }).reference;
+            return json(REFERENCE_USED, 422);
+          },
+        },
+        {
+          method: "GET",
+          path: /\/transactions\?reference=/,
+          respond: () =>
+            json({
+              data: [
+                {
+                  ...transaction("tx_old", "PENDING", reference),
+                  created_at: "2026-08-18T10:00:00.000Z",
+                },
+                {
+                  ...transaction("tx_new", "DECLINED", reference),
+                  created_at: "2026-08-18T10:05:00.000Z",
+                },
+              ],
+            }),
+        },
+      ]),
+    );
+
+    const summary = await t.action(async (ctx) => await wompi.processBilling(ctx));
+    expect(summary.declined).toBe(1);
+
+    const payments = await paymentsOf(t, subscription._id);
+    const renewal = payments.find((p) => p.periodStart);
+    expect(renewal?.status).toBe("declined");
+    expect(renewal?.wompiTransactionId).toBe("tx_new");
+  });
+
   test("the sweep looks a paid checkout up by reference before expiring it", async () => {
     const t = initConvexTest();
     const { customer } = await seed(t);

--- a/packages/convex-component/src/client/billing.test.ts
+++ b/packages/convex-component/src/client/billing.test.ts
@@ -1,0 +1,662 @@
+/// <reference types="vite/client" />
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import type { FunctionReference } from "convex/server";
+import { computeEventChecksum } from "@pulgueta/wompi/server";
+import type { ChargeOutcome, WompiConfig } from "./index.js";
+import { Wompi } from "./index.js";
+import { components, initConvexTest } from "./setup.test.js";
+
+const EVENTS_KEY = "test_events_key";
+const REFERENCE_USED = {
+  error: {
+    type: "INPUT_VALIDATION_ERROR",
+    messages: { reference: ["La referencia ya ha sido usada"] },
+  },
+};
+
+const json = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+
+const merchant = () =>
+  json({
+    data: {
+      id: 1,
+      presigned_acceptance: {
+        acceptance_token: "acc_token",
+        permalink: "https://wompi.co/terms.pdf",
+        type: "END_USER_POLICY",
+      },
+      presigned_personal_data_auth: {
+        acceptance_token: "personal_token",
+        permalink: "https://wompi.co/personal-data.pdf",
+        type: "PERSONAL_DATA_AUTH",
+      },
+    },
+  });
+
+const transaction = (id: string, status: string, reference: string, amount = 2_990_000) => ({
+  id,
+  status,
+  reference,
+  amount_in_cents: amount,
+  currency: "COP",
+  payment_method_type: "CARD",
+  created_at: "2026-08-18T10:00:00.000Z",
+});
+
+type Route = {
+  method: string;
+  path: RegExp;
+  respond: (init?: RequestInit) => Response | Promise<Response>;
+};
+
+/** Route-based fetch mock so each test declares the Wompi API it expects. */
+const routeFetch = (routes: Route[]) =>
+  vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    const method = init?.method ?? "GET";
+    const route = routes.find((r) => r.method === method && r.path.test(url));
+    if (!route) throw new Error(`Unexpected fetch ${method} ${url}`);
+    return await route.respond(init);
+  });
+
+const CARD = {
+  wompiSourceId: 1234,
+  type: "CARD",
+  status: "AVAILABLE",
+  brand: "VISA",
+  lastFour: "4242",
+};
+
+const makeWompi = (overrides: Partial<WompiConfig> = {}) =>
+  new Wompi(components.wompi, {
+    getUserInfo: async () => ({ userId: "user_1", email: "ada@example.com" }),
+    publicKey: "pub_test_key",
+    privateKey: "prv_test_key",
+    eventsKey: EVENTS_KEY,
+    integrityKey: "integrity_key",
+    sandbox: true,
+    billing: {
+      leaseMs: 0,
+      pollAttempts: 1,
+      pollIntervalMs: 0,
+      pendingSweepAfterMs: 0,
+    },
+    ...overrides,
+  });
+
+async function seed(t: ReturnType<typeof initConvexTest>) {
+  const customer = await t.mutation(components.wompi.customers.upsert, {
+    userId: "user_1",
+    email: "ada@example.com",
+  });
+  await t.mutation(components.wompi.products.sync, {
+    products: [
+      {
+        key: "pro-monthly",
+        name: "Pro",
+        type: "subscription" as const,
+        amountInCents: 2_990_000,
+        interval: "month" as const,
+      },
+      {
+        key: "sticker-pack",
+        name: "Sticker pack",
+        type: "one_time" as const,
+        amountInCents: 500_000,
+      },
+    ],
+  });
+  return { customer };
+}
+
+/** An active subscription whose renewal is due now. */
+async function dueRenewal(t: ReturnType<typeof initConvexTest>) {
+  const { customer } = await seed(t);
+  const created = await t.mutation(components.wompi.subscriptions.create, {
+    customerId: customer._id,
+    userId: "user_1",
+    productKey: "pro-monthly",
+    paymentSource: CARD,
+  });
+  await t.mutation(components.wompi.billing.recordChargeResult, {
+    paymentId: created.payment!._id,
+    nextStatus: "approved",
+    wompiTransactionId: "tx_init",
+    config: {
+      maxRetries: 3,
+      retryScheduleMs: [1_000],
+      onExhausted: "mark_unpaid",
+      leaseMs: 0,
+    },
+  });
+  await t.mutation(components.wompi.subscriptions.setNextChargeAt, {
+    subscriptionId: created.subscription._id,
+    at: Date.now() - 1_000,
+  });
+  return created.subscription;
+}
+
+// Component tables live in the component's own database, so read them back
+// through the component's queries rather than `t.run`.
+const paymentsOf = async (t: ReturnType<typeof initConvexTest>, subscriptionId: string) =>
+  (await t.query(components.wompi.payments.listByUser, { userId: "user_1" })).filter(
+    (p) => p.subscriptionId === subscriptionId,
+  );
+
+const subscriptionOf = (t: ReturnType<typeof initConvexTest>, subscriptionId: string) =>
+  t.query(components.wompi.subscriptions.get, {
+    subscriptionId: subscriptionId as never,
+  });
+
+describe("renewal charge idempotency", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("a transport error leaves the payment pending and the next claim reconciles by reference", async () => {
+    const t = initConvexTest();
+    const subscription = await dueRenewal(t);
+
+    const posted: string[] = [];
+    let lookups = 0;
+    // The first request reaches Wompi but its response never comes back;
+    // Wompi only exposes the resulting transaction a little later.
+    let wompiSide: ReturnType<typeof transaction> | null = null;
+    let listable = false;
+    const fetchMock = routeFetch([
+      { method: "GET", path: /\/merchants\//, respond: () => merchant() },
+      {
+        method: "POST",
+        path: /\/transactions$/,
+        respond: (init) => {
+          const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+          posted.push(body.reference as string);
+          expect(body.acceptance_token).toBe("acc_token");
+          expect(body.accept_personal_auth).toBe("personal_token");
+          if (wompiSide === null) {
+            wompiSide = transaction("tx_renewal", "APPROVED", body.reference as string);
+            throw new TypeError("fetch failed");
+          }
+          return json(REFERENCE_USED, 422);
+        },
+      },
+      {
+        method: "GET",
+        path: /\/transactions\?reference=/,
+        respond: () => {
+          lookups++;
+          return json({ data: listable && wompiSide ? [wompiSide] : [] });
+        },
+      },
+    ]);
+    vi.stubGlobal("fetch", fetchMock);
+
+    const changes: string[] = [];
+    const wompiWithEvents = makeWompi({
+      events: {
+        onPaymentChange: async (_ctx, payment) => {
+          changes.push(payment.status);
+        },
+      },
+    });
+
+    const first = await t.action(async (ctx) => await wompiWithEvents.processBilling(ctx));
+    expect(first.claimed).toBe(1);
+    expect(first.stillPending).toBe(1);
+    expect(first.declined).toBe(0);
+    expect(first.errors).toHaveLength(1);
+    expect(first.errors[0]).toContain("status 0");
+    // The sweep already asked Wompi about the reference in the same run.
+    expect(lookups).toBe(1);
+    listable = true;
+
+    let payments = await paymentsOf(t, subscription._id);
+    const renewal = payments.find((p) => p.reference.endsWith("_a0") && p.periodStart);
+    expect(renewal?.status).toBe("pending");
+    expect(renewal?.wompiTransactionId).toBeUndefined();
+
+    // Nothing was finalized, so no callback fired and the subscription is
+    // untouched (no dunning step, no fresh reference).
+    expect(changes).toEqual([]);
+    const sub = await subscriptionOf(t, subscription._id);
+    expect(sub?.status).toBe("active");
+    expect(sub?.failedAttempts).toBe(0);
+
+    // Lease expired (leaseMs 0): the next run re-claims the SAME reference,
+    // Wompi rejects the duplicate, and the existing transaction is applied.
+    const second = await t.action(async (ctx) => await wompiWithEvents.processBilling(ctx));
+    expect(second.claimed).toBe(1);
+    expect(second.approved).toBe(1);
+    expect(second.errors).toEqual([]);
+
+    payments = await paymentsOf(t, subscription._id);
+    const settled = payments.find((p) => p._id === renewal!._id);
+    expect(settled?.status).toBe("approved");
+    expect(settled?.wompiTransactionId).toBe("tx_renewal");
+    expect(payments.filter((p) => p.status === "pending")).toHaveLength(0);
+    expect(posted).toEqual([renewal!.reference, renewal!.reference]);
+    expect(changes).toEqual(["approved"]);
+  });
+
+  test("a rejected request (4xx) finalizes the attempt as an error", async () => {
+    const t = initConvexTest();
+    const subscription = await dueRenewal(t);
+    const wompi = makeWompi();
+
+    vi.stubGlobal(
+      "fetch",
+      routeFetch([
+        { method: "GET", path: /\/merchants\//, respond: () => merchant() },
+        {
+          method: "POST",
+          path: /\/transactions$/,
+          respond: () => json({ error: { type: "UNAUTHORIZED", reason: "bad key" } }, 401),
+        },
+        {
+          method: "GET",
+          path: /\/transactions\?reference=/,
+          respond: () => json({ data: [] }),
+        },
+      ]),
+    );
+
+    const summary = await t.action(async (ctx) => await wompi.processBilling(ctx));
+    expect(summary.declined).toBe(1);
+
+    const payments = await paymentsOf(t, subscription._id);
+    const renewal = payments.find((p) => p.periodStart);
+    expect(renewal?.status).toBe("error");
+    const sub = await subscriptionOf(t, subscription._id);
+    expect(sub?.status).toBe("past_due");
+    expect(sub?.failedAttempts).toBe(1);
+  });
+
+  test("the sweep looks a paid checkout up by reference before expiring it", async () => {
+    const t = initConvexTest();
+    const { customer } = await seed(t);
+    const wompi = makeWompi({
+      billing: { pendingSweepAfterMs: 0, expirePendingAfterMs: 0 },
+    });
+
+    await t.mutation(components.wompi.payments.createCheckout, {
+      reference: "wmpk_paid_offline",
+      customerId: customer._id,
+      userId: "user_1",
+      productKey: "sticker-pack",
+    });
+    await t.mutation(components.wompi.payments.createCheckout, {
+      reference: "wmpk_abandoned",
+      customerId: customer._id,
+      userId: "user_1",
+      productKey: "sticker-pack",
+    });
+
+    vi.stubGlobal(
+      "fetch",
+      routeFetch([
+        {
+          method: "GET",
+          path: /\/transactions\?reference=wmpk_paid_offline/,
+          respond: () =>
+            json({
+              data: [
+                transaction("tx_declined", "DECLINED", "wmpk_paid_offline", 500_000),
+                transaction("tx_paid", "APPROVED", "wmpk_paid_offline", 500_000),
+              ],
+            }),
+        },
+        {
+          method: "GET",
+          path: /\/transactions\?reference=wmpk_abandoned/,
+          respond: () => json({ data: [] }),
+        },
+      ]),
+    );
+
+    // Let the rows age past the (zero) expiry window.
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    const summary = await t.action(async (ctx) => await wompi.processBilling(ctx));
+    expect(summary.sweptPending).toBe(1);
+    expect(summary.expired).toBe(1);
+
+    const paid = await t.query(components.wompi.payments.getByReference, {
+      reference: "wmpk_paid_offline",
+    });
+    expect(paid?.status).toBe("approved");
+    expect(paid?.wompiTransactionId).toBe("tx_paid");
+    const abandoned = await t.query(components.wompi.payments.getByReference, {
+      reference: "wmpk_abandoned",
+    });
+    expect(abandoned?.status).toBe("expired");
+  });
+});
+
+describe("payments webhook", () => {
+  const routes = new Map<
+    string,
+    { _handler: (ctx: unknown, request: Request) => Promise<Response> }
+  >();
+  const http = {
+    route: (spec: { path: string; handler: unknown }) => {
+      routes.set(spec.path, spec.handler as never);
+    },
+  };
+
+  const signedEvent = async (overrides: Record<string, unknown> = {}) => {
+    const event = {
+      event: "transaction.updated",
+      data: {
+        transaction: {
+          id: "tx_hook",
+          status: "APPROVED",
+          reference: "wmpk_hook",
+          amount_in_cents: 500_000,
+          currency: "COP",
+        },
+      },
+      environment: "test",
+      signature: {
+        properties: ["transaction.id", "transaction.status", "transaction.amount_in_cents"],
+        checksum: "",
+      },
+      timestamp: 1_700_000_000,
+      sent_at: "2026-08-18T10:00:00.000Z",
+      ...overrides,
+    };
+    event.signature.checksum = await computeEventChecksum(event as never, EVENTS_KEY);
+    return event;
+  };
+
+  const post = (body: unknown) =>
+    new Request("https://example.convex.site/wompi/webhook", {
+      method: "POST",
+      body: JSON.stringify(body),
+    });
+
+  /** Actions must return Convex values, so unwrap the Response first. */
+  const deliver = async (
+    handler: (ctx: unknown, request: Request) => Promise<Response>,
+    ctx: unknown,
+    body: unknown,
+  ) => {
+    const response = await handler(ctx, post(body));
+    return {
+      status: response.status,
+      body: (await response.json()) as unknown,
+    };
+  };
+
+  const recordedEvent = (t: ReturnType<typeof initConvexTest>, checksum: string) =>
+    t.mutation(components.wompi.webhooks.recordEvent, {
+      checksum,
+      eventType: "transaction.updated",
+      timestamp: 1_700_000_000,
+    });
+
+  beforeEach(() => {
+    routes.clear();
+  });
+
+  test("rejects a bad checksum with 403 and records nothing", async () => {
+    const t = initConvexTest();
+    await seed(t);
+    makeWompi().registerRoutes(http as never);
+    const handler = routes.get("/wompi/webhook")!._handler;
+
+    const event = await signedEvent();
+    event.signature.checksum = "deadbeef";
+    const response = await t.action(async (ctx) => await deliver(handler, ctx, event));
+
+    expect(response.status).toBe(403);
+    // Nothing was recorded: recording it now reports a fresh delivery.
+    expect((await recordedEvent(t, "deadbeef")).duplicate).toBe(false);
+  });
+
+  test("a crash after recording the delivery is repaired by Wompi's retry", async () => {
+    const t = initConvexTest();
+    const { customer } = await seed(t);
+    await t.mutation(components.wompi.payments.createCheckout, {
+      reference: "wmpk_hook",
+      customerId: customer._id,
+      userId: "user_1",
+      productKey: "sticker-pack",
+    });
+
+    const callbacks: string[] = [];
+    makeWompi({
+      events: {
+        onPaymentChange: async (_ctx, payment) => {
+          callbacks.push(payment.status);
+        },
+      },
+    }).registerRoutes(http as never);
+    const handler = routes.get("/wompi/webhook")!._handler;
+    const event = await signedEvent();
+
+    // First delivery: the event is recorded, then applying it fails (OCC,
+    // transient error) and the endpoint answers 500 → Wompi retries.
+    let crashOnce = true;
+    await expect(
+      t.action(async (ctx) => {
+        const flaky = {
+          ...ctx,
+          runMutation: async (ref: FunctionReference<"mutation">, args: unknown) => {
+            // `applyTransaction` is the only mutation carrying a Wompi status.
+            if (crashOnce && typeof args === "object" && args !== null && "wompiStatus" in args) {
+              crashOnce = false;
+              throw new Error("write conflict");
+            }
+            return await ctx.runMutation(ref, args as never);
+          },
+        };
+        return await deliver(handler, flaky, event);
+      }),
+    ).rejects.toThrow("write conflict");
+
+    let payment = await t.query(components.wompi.payments.getByReference, {
+      reference: "wmpk_hook",
+    });
+    expect(payment?.status).toBe("pending");
+    expect(callbacks).toEqual([]);
+
+    // Retry: same checksum → duplicate delivery, but with no recorded
+    // outcome it must be reprocessed, not short-circuited.
+    const retry = await t.action(async (ctx) => await deliver(handler, ctx, event));
+    expect(retry.status).toBe(200);
+    expect(retry.body).toEqual({ received: true, duplicate: true });
+
+    payment = await t.query(components.wompi.payments.getByReference, {
+      reference: "wmpk_hook",
+    });
+    expect(payment?.status).toBe("approved");
+    expect(payment?.wompiTransactionId).toBe("tx_hook");
+    expect(callbacks).toEqual(["approved"]);
+
+    // A third delivery is a plain duplicate: no reprocessing, no callback.
+    const third = await t.action(async (ctx) => await deliver(handler, ctx, event));
+    expect(third.body).toEqual({ received: true, duplicate: true });
+    expect(callbacks).toEqual(["approved"]);
+
+    const recorded = await recordedEvent(t, event.signature.checksum);
+    expect(recorded.duplicate).toBe(true);
+    expect(recorded.outcome).toBe("applied");
+  });
+});
+
+// Registered Convex functions keep the raw handler on `_handler` (how convex-test
+// itself invokes them); calling it directly runs the function without an
+// `api` module wired up.
+type Handler = (ctx: unknown, args: Record<string, unknown>) => Promise<unknown>;
+const handlerOf = (fn: unknown): Handler => (fn as { _handler: Handler })._handler;
+const exportedArgs = (fn: unknown) =>
+  JSON.parse((fn as { exportArgs: () => string }).exportArgs()) as {
+    value: Record<string, { optional: boolean }>;
+  };
+
+describe("prebuilt api()", () => {
+  const authedConfig: Partial<WompiConfig> = {
+    getUserInfo: async (ctx) => {
+      const identity = await ctx.auth.getUserIdentity();
+      if (!identity) throw new Error("Unauthenticated");
+      return {
+        userId: identity.subject,
+        email: identity.email ?? "user@example.com",
+      };
+    },
+  };
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("checkout only accepts a catalog product — no client-supplied amount or metadata", () => {
+    const api = makeWompi().api();
+    const args = exportedArgs(api.checkout);
+    expect(args.value.productKey.optional).toBe(false);
+    expect(args.value.redirectUrl.optional).toBe(false);
+    expect(Object.keys(args.value).sort()).toEqual(["productKey", "redirectUrl"]);
+  });
+
+  test("every identity-bound function resolves the user through getUserInfo", async () => {
+    const t = initConvexTest();
+    await seed(t);
+    const api = makeWompi(authedConfig).api();
+
+    const calls: [string, () => Promise<unknown>][] = [
+      [
+        "getCurrentSubscription",
+        () => t.query(async (ctx) => await handlerOf(api.getCurrentSubscription)(ctx, {})),
+      ],
+      [
+        "listSubscriptions",
+        () => t.query(async (ctx) => await handlerOf(api.listSubscriptions)(ctx, {})),
+      ],
+      ["listPayments", () => t.query(async (ctx) => await handlerOf(api.listPayments)(ctx, {}))],
+      [
+        "getPayment",
+        () => t.query(async (ctx) => await handlerOf(api.getPayment)(ctx, { reference: "x" })),
+      ],
+      [
+        "checkout",
+        () =>
+          t.action(
+            async (ctx) =>
+              await handlerOf(api.checkout)(ctx, {
+                redirectUrl: "https://app.test",
+                productKey: "sticker-pack",
+              }),
+          ),
+      ],
+      [
+        "confirmTransaction",
+        () =>
+          t.action(
+            async (ctx) =>
+              await handlerOf(api.confirmTransaction)(ctx, {
+                transactionId: "tx",
+              }),
+          ),
+      ],
+      [
+        "subscribe",
+        () =>
+          t.action(
+            async (ctx) =>
+              await handlerOf(api.subscribe)(ctx, {
+                productKey: "pro-monthly",
+                token: "tok",
+              }),
+          ),
+      ],
+      [
+        "cancelSubscription",
+        () =>
+          t.mutation(
+            async (ctx) =>
+              await handlerOf(api.cancelSubscription)(ctx, {
+                subscriptionId: "s",
+              }),
+          ),
+      ],
+      [
+        "resumeSubscription",
+        () =>
+          t.mutation(
+            async (ctx) =>
+              await handlerOf(api.resumeSubscription)(ctx, {
+                subscriptionId: "s",
+              }),
+          ),
+      ],
+      [
+        "changeSubscription",
+        () =>
+          t.mutation(
+            async (ctx) =>
+              await handlerOf(api.changeSubscription)(ctx, {
+                subscriptionId: "s",
+                productKey: "pro-monthly",
+              }),
+          ),
+      ],
+    ];
+
+    // Anonymous callers are rejected before anything reaches Wompi.
+    vi.stubGlobal("fetch", routeFetch([]));
+    for (const [name, call] of calls) {
+      await expect(call(), name).rejects.toThrow("Unauthenticated");
+    }
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  test("confirmTransaction redacts payments that belong to another user", async () => {
+    const t = initConvexTest();
+    const { customer } = await seed(t);
+    await t.mutation(components.wompi.payments.createCheckout, {
+      reference: "wmpk_mine",
+      customerId: customer._id,
+      userId: "user_1",
+      productKey: "sticker-pack",
+    });
+    vi.stubGlobal(
+      "fetch",
+      routeFetch([
+        {
+          method: "GET",
+          path: /\/transactions\/tx_mine$/,
+          respond: () =>
+            json({
+              data: transaction("tx_mine", "APPROVED", "wmpk_mine", 500_000),
+            }),
+        },
+      ]),
+    );
+    const api = makeWompi(authedConfig).api();
+
+    // Anyone can hold a transaction id (it travels in the redirect URL);
+    // another signed-in user gets the state machine's verdict, not the row.
+    const asOther = (await t.withIdentity({ subject: "user_2", email: "bob@example.com" }).action(
+      async (ctx) =>
+        await handlerOf(api.confirmTransaction)(ctx, {
+          transactionId: "tx_mine",
+        }),
+    )) as ChargeOutcome;
+    expect(asOther.outcome).toBe("applied");
+    expect(asOther.payment).toBeNull();
+    expect(asOther.subscription).toBeNull();
+
+    const asOwner = (await t.withIdentity({ subject: "user_1", email: "ada@example.com" }).action(
+      async (ctx) =>
+        await handlerOf(api.confirmTransaction)(ctx, {
+          transactionId: "tx_mine",
+        }),
+    )) as ChargeOutcome;
+    expect(asOwner.outcome).toBe("noop");
+    expect(asOwner.payment?.userId).toBe("user_1");
+    expect(asOwner.payment?.status).toBe("approved");
+  });
+});

--- a/packages/convex-component/src/client/index.ts
+++ b/packages/convex-component/src/client/index.ts
@@ -222,35 +222,26 @@ const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 /** Both acceptance tokens Wompi requires on transactions and payment sources. */
 type AcceptanceTokens = {
   acceptanceToken: string;
-  /** Personal-data authorization (habeas data); absent on merchants without it. */
-  personalAuthToken?: string;
+  /** Personal-data authorization (habeas data). */
+  personalAuthToken: string;
 };
 
 const acceptanceTokensFrom = (merchant: Merchant): AcceptanceTokens | null => {
   const acceptanceToken = merchant.presigned_acceptance?.acceptance_token;
-  if (!acceptanceToken) return null;
-  return {
-    acceptanceToken,
-    personalAuthToken: merchant.presigned_personal_data_auth?.acceptance_token,
-  };
-};
-
-const TRANSACTION_STATUS_RANK: Record<string, number> = {
-  APPROVED: 0,
-  PENDING: 1,
-  VOIDED: 2,
-  DECLINED: 3,
-  ERROR: 4,
+  const personalAuthToken = merchant.presigned_personal_data_auth?.acceptance_token;
+  if (!acceptanceToken || !personalAuthToken) return null;
+  return { acceptanceToken, personalAuthToken };
 };
 
 /**
  * The transaction that decides a reference when Wompi holds several for it
- * (payer retries): an approved one wins, then the newest.
+ * (payer retries): an approved one wins, then the newest — so a newer
+ * terminal result (DECLINED, VOIDED, ERROR) beats an older PENDING one.
  */
 const pickTransaction = (transactions: Transaction[]): Transaction =>
   [...transactions].sort(
     (a, b) =>
-      (TRANSACTION_STATUS_RANK[a.status] ?? 9) - (TRANSACTION_STATUS_RANK[b.status] ?? 9) ||
+      Number(b.status === "APPROVED") - Number(a.status === "APPROVED") ||
       (b.created_at ?? "").localeCompare(a.created_at ?? ""),
   )[0];
 
@@ -570,7 +561,7 @@ export class Wompi {
     if (merchantError) throw merchantError;
     const tokens = acceptanceTokensFrom(merchant);
     if (!tokens) {
-      throw new Error("Could not fetch the merchant acceptance token from Wompi");
+      throw new Error("Could not fetch the merchant acceptance tokens from Wompi");
     }
 
     const [sourceError, source] = await this.client.paymentSources.createPaymentSource({
@@ -673,6 +664,20 @@ export class Wompi {
         const [listError, existing] = await this.client.transactions.listTransactions({
           reference: payment.reference,
         });
+        if (listError && "reference" in chargeError.messages) {
+          // Wompi rejected the reference, so a transaction exists for it. If
+          // we cannot list it right now, marking `error` would let the next
+          // attempt charge under a fresh reference. Leave the row pending for
+          // the sweep to reconcile by reference.
+          return {
+            outcome: "unresolved",
+            paymentChanged: false,
+            subscriptionChanged: false,
+            payment,
+            subscription: null,
+            note: listError.message,
+          };
+        }
         if (!listError && existing.length > 0) {
           return await this.applyWompiTransaction(ctx, pickTransaction(existing));
         }
@@ -895,7 +900,7 @@ export class Wompi {
           outcome = await this.applyWompiTransaction(ctx, transaction);
         } else {
           if (!tokens) {
-            summary.errors.push(`${claim.payment.reference}: no acceptance token`);
+            summary.errors.push(`${claim.payment.reference}: no acceptance tokens`);
             continue;
           }
           outcome = await this.chargeClaimedPayment(ctx, {
@@ -1289,6 +1294,11 @@ export class Wompi {
       path?: string;
       /** Payouts events endpoint; only used with `payouts` credentials. */
       payoutsPath?: string;
+      /**
+       * Runs after each verified delivery is applied. Make it idempotent:
+       * a redelivery that overlaps the first delivery, or arrives after a
+       * crash mid-apply, calls it again for the same checksum.
+       */
       onEvent?: (ctx: RunMutationCtx, event: WebhookEvent) => void | Promise<void>;
     },
   ) {

--- a/packages/convex-component/src/client/index.ts
+++ b/packages/convex-component/src/client/index.ts
@@ -33,13 +33,20 @@ import type {
   BrebKeyType,
   CreatePayoutInput,
   CreatePayoutResult,
+  Merchant,
   Payout,
   PayoutPage,
   Result,
   Transaction,
   WebhookEvent,
+  WompiErrorResult,
 } from "@pulgueta/wompi/schemas";
-import { WompiPayoutApiError, WompiValidationError } from "@pulgueta/wompi/schemas";
+import {
+  WompiNotFoundError,
+  WompiPayoutApiError,
+  WompiRequestError,
+  WompiValidationError,
+} from "@pulgueta/wompi/schemas";
 import type { ComponentApi } from "../component/_generated/component.js";
 import {
   dispersionDoc,
@@ -211,6 +218,61 @@ export type ProcessBillingSummary = {
 };
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/** Both acceptance tokens Wompi requires on transactions and payment sources. */
+type AcceptanceTokens = {
+  acceptanceToken: string;
+  /** Personal-data authorization (habeas data); absent on merchants without it. */
+  personalAuthToken?: string;
+};
+
+const acceptanceTokensFrom = (merchant: Merchant): AcceptanceTokens | null => {
+  const acceptanceToken = merchant.presigned_acceptance?.acceptance_token;
+  if (!acceptanceToken) return null;
+  return {
+    acceptanceToken,
+    personalAuthToken: merchant.presigned_personal_data_auth?.acceptance_token,
+  };
+};
+
+const TRANSACTION_STATUS_RANK: Record<string, number> = {
+  APPROVED: 0,
+  PENDING: 1,
+  VOIDED: 2,
+  DECLINED: 3,
+  ERROR: 4,
+};
+
+/**
+ * The transaction that decides a reference when Wompi holds several for it
+ * (payer retries): an approved one wins, then the newest.
+ */
+const pickTransaction = (transactions: Transaction[]): Transaction =>
+  [...transactions].sort(
+    (a, b) =>
+      (TRANSACTION_STATUS_RANK[a.status] ?? 9) - (TRANSACTION_STATUS_RANK[b.status] ?? 9) ||
+      (b.created_at ?? "").localeCompare(a.created_at ?? ""),
+  )[0];
+
+/**
+ * Whether a failed charge request may still have created a transaction at
+ * Wompi. Only a rejected request (validation, not found, other 4xx) proves
+ * nothing was created; timeouts, network failures, 5xx and throttling do
+ * not — and neither does a 2xx whose body failed to parse.
+ */
+const chargeMayHaveReachedWompi = (error: WompiErrorResult): boolean => {
+  if (error instanceof WompiValidationError || error instanceof WompiNotFoundError) return false;
+  if (error instanceof WompiRequestError) {
+    return (
+      error.statusCode === 0 ||
+      error.statusCode >= 500 ||
+      error.statusCode === 408 ||
+      error.statusCode === 429
+    );
+  }
+  // The SDK rejects malformed input before any request is sent.
+  return !error.message.startsWith("Invalid input");
+};
 
 /**
  * App-facing client for the Wompi Convex component.
@@ -506,15 +568,16 @@ export class Wompi {
 
     const [merchantError, merchant] = await this.client.merchants.getMerchant();
     if (merchantError) throw merchantError;
-    const acceptanceToken = merchant.presigned_acceptance?.acceptance_token;
-    if (!acceptanceToken) {
+    const tokens = acceptanceTokensFrom(merchant);
+    if (!tokens) {
       throw new Error("Could not fetch the merchant acceptance token from Wompi");
     }
 
     const [sourceError, source] = await this.client.paymentSources.createPaymentSource({
       type: args.type ?? "CARD",
       token: args.token,
-      acceptance_token: acceptanceToken,
+      acceptance_token: tokens.acceptanceToken,
+      accept_personal_auth: tokens.personalAuthToken,
       customer_email: user.email,
     });
     if (sourceError) throw sourceError;
@@ -551,7 +614,7 @@ export class Wompi {
       payment,
       customerEmail: user.email,
       wompiSourceId: source.id,
-      acceptanceToken,
+      tokens,
       integrityKey,
       pollAttempts: this.billingOptions.pollAttempts,
       installments: args.installments,
@@ -575,7 +638,7 @@ export class Wompi {
       payment: PaymentDoc;
       customerEmail: string;
       wompiSourceId: number;
-      acceptanceToken: string;
+      tokens: AcceptanceTokens;
       integrityKey: string;
       pollAttempts: number;
       installments?: number;
@@ -591,7 +654,8 @@ export class Wompi {
     });
 
     const [chargeError, transaction] = await this.client.transactions.createTransaction({
-      acceptance_token: args.acceptanceToken,
+      acceptance_token: args.tokens.acceptanceToken,
+      accept_personal_auth: args.tokens.personalAuthToken,
       amount_in_cents: payment.amountInCents,
       currency: payment.currency,
       signature,
@@ -610,8 +674,24 @@ export class Wompi {
           reference: payment.reference,
         });
         if (!listError && existing.length > 0) {
-          return await this.applyWompiTransaction(ctx, existing[0]);
+          return await this.applyWompiTransaction(ctx, pickTransaction(existing));
         }
+      }
+
+      if (chargeMayHaveReachedWompi(chargeError)) {
+        // Wompi may hold a transaction we never saw (timeout, 5xx, network).
+        // Recording a terminal `error` now would let the next attempt charge
+        // under a fresh reference — a double charge. Leave the row pending:
+        // the next claim reuses this reference (Wompi rejects the duplicate
+        // and we reconcile), and the sweep reconciles by reference meanwhile.
+        return {
+          outcome: "unresolved",
+          paymentChanged: false,
+          subscriptionChanged: false,
+          payment,
+          subscription: null,
+          note: chargeError.message,
+        };
       }
 
       const outcome = (await ctx.runMutation(this.component.billing.recordChargeResult, {
@@ -788,7 +868,7 @@ export class Wompi {
       });
     }
 
-    let acceptanceToken: string | null = null;
+    let tokens: AcceptanceTokens | null = null;
 
     if (claims.some((c) => c.action === "charge")) {
       this.requireKey(this.privateKey, "private key", "WOMPI_PRIVATE_KEY");
@@ -796,7 +876,7 @@ export class Wompi {
       if (merchantError) {
         summary.errors.push(`merchant: ${merchantError.message}`);
       } else {
-        acceptanceToken = merchant.presigned_acceptance?.acceptance_token ?? null;
+        tokens = acceptanceTokensFrom(merchant);
       }
     }
 
@@ -814,7 +894,7 @@ export class Wompi {
           }
           outcome = await this.applyWompiTransaction(ctx, transaction);
         } else {
-          if (!acceptanceToken) {
+          if (!tokens) {
             summary.errors.push(`${claim.payment.reference}: no acceptance token`);
             continue;
           }
@@ -822,7 +902,7 @@ export class Wompi {
             payment: claim.payment,
             customerEmail: claim.customerEmail,
             wompiSourceId: claim.wompiSourceId,
-            acceptanceToken,
+            tokens,
             integrityKey: this.requireKey(
               this.integrityKey,
               "integrity key",
@@ -834,6 +914,9 @@ export class Wompi {
         }
 
         if (claim.action === "reconcile") summary.reconciled++;
+        if (outcome.outcome === "unresolved") {
+          summary.errors.push(`${claim.payment.reference}: ${outcome.note ?? "charge unresolved"}`);
+        }
         const status = outcome.payment?.status;
         if (status === "approved") summary.approved++;
         else if (status === "declined" || status === "error") summary.declined++;
@@ -869,8 +952,29 @@ export class Wompi {
         const neverCharged =
           payment.kind === "checkout" ||
           (payment.kind === "subscription" && payment.periodStart === undefined);
+        const shouldExpire = neverCharged && age > this.billingOptions.expirePendingAfterMs;
 
-        if (neverCharged && age > this.billingOptions.expirePendingAfterMs) {
+        // No transaction id here does not mean no transaction at Wompi: a
+        // server-side charge may have landed after a timeout, and a checkout
+        // may have been paid without the webhook or redirect reaching us. Ask
+        // Wompi by reference — every sweep for server-side charges, and once
+        // before giving up on a checkout.
+        if (this.privateKey && (payment.kind === "subscription" || shouldExpire)) {
+          const [error, existing] = await this.client.transactions.listTransactions({
+            reference: payment.reference,
+          });
+          if (error) {
+            summary.errors.push(`sweep ${payment.reference}: ${error.message}`);
+            continue;
+          }
+          if (existing.length > 0) {
+            const outcome = await this.applyWompiTransaction(ctx, pickTransaction(existing));
+            if (outcome.paymentChanged) summary.sweptPending++;
+            continue;
+          }
+        }
+
+        if (shouldExpire) {
           const outcome = (await ctx.runMutation(this.component.billing.recordChargeResult, {
             paymentId: payment._id,
             nextStatus: "expired",
@@ -1210,25 +1314,26 @@ export class Wompi {
           ? event.data.transaction
           : undefined;
 
-        const { duplicate, eventId } = (await ctx.runMutation(
-          this.component.webhooks.recordEvent,
-          {
-            checksum: event.signature.checksum,
-            eventType: event.event,
-            environment: event.environment,
-            timestamp: event.timestamp,
-            sentAt: event.sent_at,
-            transactionId: transaction?.id,
-            reference: transaction?.reference,
-          },
-        )) as { duplicate: boolean; eventId: string };
+        const delivery = (await ctx.runMutation(this.component.webhooks.recordEvent, {
+          checksum: event.signature.checksum,
+          eventType: event.event,
+          environment: event.environment,
+          timestamp: event.timestamp,
+          sentAt: event.sent_at,
+          transactionId: transaction?.id,
+          reference: transaction?.reference,
+        })) as { duplicate: boolean; eventId: string; outcome?: string };
 
-        if (duplicate) {
+        // A duplicate with no recorded outcome crashed between recording and
+        // applying on a previous delivery; Wompi's retry must reprocess it,
+        // not be told it was handled.
+        if (delivery.duplicate && delivery.outcome !== undefined) {
           return new Response(JSON.stringify({ received: true, duplicate: true }), {
             status: 200,
             headers: { "Content-Type": "application/json" },
           });
         }
+        const eventId = delivery.eventId;
 
         let outcome = "ignored";
 
@@ -1248,7 +1353,7 @@ export class Wompi {
           console.error("Wompi onEvent callback failed:", callbackError);
         }
 
-        return new Response(JSON.stringify({ received: true }), {
+        return new Response(JSON.stringify({ received: true, duplicate: delivery.duplicate }), {
           status: 200,
           headers: { "Content-Type": "application/json" },
         });
@@ -1433,25 +1538,46 @@ export class Wompi {
         },
       }),
 
+      /**
+       * Client-facing checkout: the amount always comes from the catalog
+       * (`productKey`), never from the browser. Use `wompi.checkout(ctx, …)`
+       * in your own server function for custom amounts or metadata.
+       */
       checkout: actionGeneric({
         args: {
           redirectUrl: v.string(),
-          productKey: v.optional(v.string()),
-          amountInCents: v.optional(v.number()),
-          description: v.optional(v.string()),
-          metadata: v.optional(v.record(v.string(), v.any())),
+          productKey: v.string(),
         },
         returns: v.object({ url: v.string(), reference: v.string() }),
         handler: async (ctx, args) => {
-          const { url, reference } = await this.checkout(ctx, args);
+          const { url, reference } = await this.checkout(ctx, {
+            redirectUrl: args.redirectUrl,
+            productKey: args.productKey,
+          });
           return { url, reference };
         },
       }),
 
+      /**
+       * Redirect-return confirmation for the signed-in user. Rows that belong
+       * to someone else (or to nobody the component knows) only reveal the
+       * outcome code, never the payment.
+       */
       confirmTransaction: actionGeneric({
         args: { transactionId: v.string() },
-        handler: async (ctx, args) => {
-          return await this.confirmTransaction(ctx, { transactionId: args.transactionId });
+        handler: async (ctx, args): Promise<ChargeOutcome> => {
+          const user = await getUser(ctx);
+          const outcome = await this.confirmTransaction(ctx, {
+            transactionId: args.transactionId,
+          });
+          if (outcome.payment && outcome.payment.userId === user.userId) return outcome;
+          return {
+            outcome: outcome.outcome,
+            paymentChanged: false,
+            subscriptionChanged: false,
+            payment: null,
+            subscription: null,
+          };
         },
       }),
 

--- a/packages/convex-component/src/component/billing.test.ts
+++ b/packages/convex-component/src/component/billing.test.ts
@@ -577,6 +577,65 @@ describe("subscription lifecycle", () => {
     });
     expect(retriedAgain.payment!._id).toBe(retried.payment!._id);
     expect(retriedAgain.payment!.reference).toBe(retried.payment!.reference);
+
+    // The resume charge is declined as well: the next resume mints a new
+    // reference instead of reusing the settled one.
+    await t.mutation(api.billing.recordChargeResult, {
+      paymentId: retried.payment!._id,
+      nextStatus: "declined",
+      failureReason: "Card declined",
+      config: CONFIG,
+    });
+    const third = await t.mutation(api.subscriptions.create, {
+      customerId: customer._id,
+      userId: "user_1",
+      productKey: "pro-monthly",
+      paymentSource: CARD,
+    });
+    expect(third.payment!._id).not.toBe(retried.payment!._id);
+    expect(third.payment!.attempt).toBe(2);
+    expect(third.payment!.reference).toBe(`wmps_${created.subscription._id}_resume_a2`);
+    expect(third.subscription.resumeAttempts).toBe(2);
+  });
+
+  test("resume numbering skips references held by rows from before the counter", async () => {
+    const t = initConvexTest();
+    const { customer } = await seed(t);
+
+    const created = await t.mutation(api.subscriptions.create, {
+      customerId: customer._id,
+      userId: "user_1",
+      productKey: "pro-monthly",
+      paymentSource: CARD,
+    });
+    await t.mutation(api.billing.recordChargeResult, {
+      paymentId: created.payment!._id,
+      nextStatus: "declined",
+      failureReason: "Card declined",
+      config: CONFIG,
+    });
+
+    // A subscription resumed by an earlier release: the row exists, the
+    // counter does not.
+    const legacyReference = `wmps_${created.subscription._id}_resume_a1`;
+    const { _id: _legacyId, _creationTime: _legacyCreated, ...legacyRow } = created.payment!;
+    await t.run(async (ctx) => {
+      await ctx.db.insert("payments", {
+        ...legacyRow,
+        reference: legacyReference,
+        status: "declined",
+        attempt: 1,
+      });
+    });
+
+    const retried = await t.mutation(api.subscriptions.create, {
+      customerId: customer._id,
+      userId: "user_1",
+      productKey: "pro-monthly",
+      paymentSource: CARD,
+    });
+    expect(retried.payment!.reference).toBe(`wmps_${created.subscription._id}_resume_a2`);
+    expect(retried.subscription.resumeAttempts).toBe(2);
   });
 
   test("subscribing twice while the initial charge is in flight reuses the pending payment", async () => {

--- a/packages/convex-component/src/component/billing.test.ts
+++ b/packages/convex-component/src/component/billing.test.ts
@@ -120,6 +120,117 @@ describe("checkout payments", () => {
     expect(result.payment?.status).toBe("pending");
   });
 
+  test("a payer retry approves a declined checkout under the same reference", async () => {
+    const t = initConvexTest();
+    const { customer } = await seed(t);
+
+    await t.mutation(api.payments.createCheckout, {
+      reference: "wmpk_retry",
+      customerId: customer._id,
+      userId: "user_1",
+      productKey: "sticker-pack",
+    });
+
+    // Web Checkout "reintento de pago": the first attempt is declined, the
+    // payer retries within minutes and Wompi creates a second transaction
+    // that shares the reference. Both arrive by webhook.
+    const declined = await t.mutation(api.billing.applyTransaction, {
+      reference: "wmpk_retry",
+      wompiTransactionId: "tx_declined",
+      wompiStatus: "DECLINED",
+      amountInCents: 500_000,
+      currency: "COP",
+      statusMessage: "Fondos insuficientes",
+      config: CONFIG,
+    });
+    expect(declined.outcome).toBe("applied");
+    expect(declined.payment?.status).toBe("declined");
+    expect(declined.payment?.failureReason).toBe("Fondos insuficientes");
+
+    const approved = await t.mutation(api.billing.applyTransaction, {
+      reference: "wmpk_retry",
+      wompiTransactionId: "tx_approved",
+      wompiStatus: "APPROVED",
+      amountInCents: 500_000,
+      currency: "COP",
+      paymentMethodType: "CARD",
+      config: CONFIG,
+    });
+
+    expect(approved.outcome).toBe("applied");
+    expect(approved.paymentChanged).toBe(true);
+    expect(approved.payment?.status).toBe("approved");
+    expect(approved.payment?.wompiTransactionId).toBe("tx_approved");
+    expect(approved.payment?.supersededTransactionIds).toEqual(["tx_declined"]);
+    expect(approved.payment?.failureReason).toBeUndefined();
+
+    // Redelivery of either transaction is a no-op afterwards.
+    const late = await t.mutation(api.billing.applyTransaction, {
+      reference: "wmpk_retry",
+      wompiTransactionId: "tx_declined",
+      wompiStatus: "DECLINED",
+      amountInCents: 500_000,
+      currency: "COP",
+      config: CONFIG,
+    });
+    expect(late.outcome).toBe("noop");
+    expect(late.payment?.status).toBe("approved");
+    expect(late.payment?.wompiTransactionId).toBe("tx_approved");
+  });
+
+  test("a late approval reopens an expired checkout, and a void closes an approved one", async () => {
+    const t = initConvexTest();
+    const { customer } = await seed(t);
+
+    const payment = await t.mutation(api.payments.createCheckout, {
+      reference: "wmpk_late",
+      customerId: customer._id,
+      userId: "user_1",
+      productKey: "sticker-pack",
+    });
+
+    const expired = await t.mutation(api.billing.recordChargeResult, {
+      paymentId: payment._id,
+      nextStatus: "expired",
+      failureReason: "Expired without a transaction",
+      config: CONFIG,
+    });
+    expect(expired.payment?.status).toBe("expired");
+
+    const approved = await t.mutation(api.billing.applyTransaction, {
+      reference: "wmpk_late",
+      wompiTransactionId: "tx_late",
+      wompiStatus: "APPROVED",
+      amountInCents: 500_000,
+      currency: "COP",
+      config: CONFIG,
+    });
+    expect(approved.outcome).toBe("applied");
+    expect(approved.payment?.status).toBe("approved");
+
+    const voided = await t.mutation(api.billing.applyTransaction, {
+      reference: "wmpk_late",
+      wompiTransactionId: "tx_late",
+      wompiStatus: "VOIDED",
+      amountInCents: 500_000,
+      currency: "COP",
+      config: CONFIG,
+    });
+    expect(voided.outcome).toBe("applied");
+    expect(voided.payment?.status).toBe("voided");
+
+    // Nothing moves a voided payment again.
+    const again = await t.mutation(api.billing.applyTransaction, {
+      reference: "wmpk_late",
+      wompiTransactionId: "tx_late",
+      wompiStatus: "APPROVED",
+      amountInCents: 500_000,
+      currency: "COP",
+      config: CONFIG,
+    });
+    expect(again.outcome).toBe("noop");
+  });
+
   test("ignores references it does not own", async () => {
     const t = initConvexTest();
     await seed(t);
@@ -466,6 +577,50 @@ describe("subscription lifecycle", () => {
     });
     expect(retriedAgain.payment!._id).toBe(retried.payment!._id);
     expect(retriedAgain.payment!.reference).toBe(retried.payment!.reference);
+  });
+
+  test("subscribing twice while the initial charge is in flight reuses the pending payment", async () => {
+    const t = initConvexTest();
+    const { customer } = await seed(t);
+
+    const first = await t.mutation(api.subscriptions.create, {
+      customerId: customer._id,
+      userId: "user_1",
+      productKey: "pro-monthly",
+      paymentSource: CARD,
+    });
+    expect(first.subscription.status).toBe("incomplete");
+    expect(first.payment!.reference).toBe(`wmps_${first.subscription._id}_init_a0`);
+
+    // Double submit / retried action before the first charge settled: the
+    // same pending row (and Wompi reference) comes back — never a second one.
+    const second = await t.mutation(api.subscriptions.create, {
+      customerId: customer._id,
+      userId: "user_1",
+      productKey: "pro-monthly",
+      paymentSource: { ...CARD, wompiSourceId: 5678 },
+    });
+    expect(second.subscription._id).toBe(first.subscription._id);
+    expect(second.payment!._id).toBe(first.payment!._id);
+    expect(second.payment!.reference).toBe(first.payment!.reference);
+    expect(second.payment!.amountInCents).toBe(first.payment!.amountInCents);
+
+    const pending = await t.run(async (ctx) =>
+      (
+        await ctx.db
+          .query("payments")
+          .withIndex("by_subscription_id", (q) => q.eq("subscriptionId", first.subscription._id))
+          .collect()
+      ).filter((p) => p.status === "pending"),
+    );
+    expect(pending).toHaveLength(1);
+
+    // The newest payment source becomes the one renewals charge.
+    const source = await t.run(async (ctx) =>
+      ctx.db.get("paymentSources", second.subscription.paymentSourceId),
+    );
+    expect(source?.wompiSourceId).toBe(5678);
+    expect(source?.termsAcceptedAt).toBeTypeOf("number");
   });
 
   test("scheduled plan change applies at the next renewal claim", async () => {

--- a/packages/convex-component/src/component/billing.ts
+++ b/packages/convex-component/src/component/billing.ts
@@ -23,6 +23,9 @@ export const chargeOutcomeValidator = v.object({
   note: v.optional(v.string()),
 });
 
+/** Settled statuses a later APPROVED/VOIDED transaction may still move. */
+const REOPENABLE_STATUSES: PaymentStatus[] = ["declined", "error", "expired"];
+
 type ChargeOutcomeInput = {
   nextStatus: PaymentStatus;
   wompiTransactionId?: string;
@@ -44,10 +47,15 @@ const applyChargeOutcome = async (
   const now = Date.now();
   const next = input.nextStatus;
 
+  // Allowed transitions. A failed or expired attempt may still end approved
+  // (or voided) later: Web Checkout lets the payer retry a declined payment
+  // within minutes under the same reference, and late webhooks can land
+  // after the sweep expired an abandoned checkout.
   const statusChanges =
     payment.status !== next &&
     (payment.status === "pending" ||
-      (payment.status === "expired" && (next === "approved" || next === "voided")) ||
+      (REOPENABLE_STATUSES.includes(payment.status) &&
+        (next === "approved" || next === "voided")) ||
       (payment.status === "approved" && next === "voided"));
 
   const patch: Partial<Doc<"payments">> = {};
@@ -55,11 +63,22 @@ const applyChargeOutcome = async (
     patch.status = next;
     if (next !== "pending") patch.finalizedAt = now;
     if (input.failureReason) patch.failureReason = input.failureReason;
+    if (next === "approved") patch.failureReason = undefined;
   }
-  if (input.wompiTransactionId && !payment.wompiTransactionId) {
-    patch.wompiTransactionId = input.wompiTransactionId;
+  if (input.wompiTransactionId && input.wompiTransactionId !== payment.wompiTransactionId) {
+    if (!payment.wompiTransactionId) {
+      patch.wompiTransactionId = input.wompiTransactionId;
+    } else if (statusChanges) {
+      // A different Wompi transaction resolved this reference (payer retry):
+      // track the new one and keep the previous id for audit.
+      patch.wompiTransactionId = input.wompiTransactionId;
+      patch.supersededTransactionIds = [
+        ...(payment.supersededTransactionIds ?? []),
+        payment.wompiTransactionId,
+      ];
+    }
   }
-  if (input.paymentMethodType && !payment.paymentMethodType) {
+  if (input.paymentMethodType && (!payment.paymentMethodType || statusChanges)) {
     patch.paymentMethodType = input.paymentMethodType;
   }
 

--- a/packages/convex-component/src/component/schema.ts
+++ b/packages/convex-component/src/component/schema.ts
@@ -87,8 +87,8 @@ export default defineSchema({
     expMonth: v.optional(v.string()),
     expYear: v.optional(v.string()),
     cardHolder: v.optional(v.string()),
-    // When the customer accepted Wompi's terms and personal-data
-    // authorization (both acceptance tokens are sent with the source).
+    // When the customer accepted Wompi's terms (the source was created with
+    // the merchant's presigned acceptance token).
     termsAcceptedAt: v.optional(v.number()),
   })
     .index("by_customer_id", ["customerId"])
@@ -124,6 +124,9 @@ export default defineSchema({
     // Scheduled plan change, applied at the next renewal (no proration).
     pendingProductId: v.optional(v.id("products")),
     pendingProductKey: v.optional(v.string()),
+    // Resume charges minted for this subscription (incomplete/unpaid retries
+    // through `subscriptions.create`); numbers their references.
+    resumeAttempts: v.optional(v.number()),
     metadata: v.optional(v.record(v.string(), v.any())),
   })
     .index("by_user_id", ["userId"])
@@ -161,6 +164,7 @@ export default defineSchema({
     .index("by_reference", ["reference"])
     .index("by_user_id", ["userId"])
     .index("by_subscription_id", ["subscriptionId"])
+    .index("by_subscription_id_status", ["subscriptionId", "status"])
     .index("by_wompi_transaction_id", ["wompiTransactionId"])
     .index("by_status", ["status"]),
 

--- a/packages/convex-component/src/component/schema.ts
+++ b/packages/convex-component/src/component/schema.ts
@@ -87,6 +87,9 @@ export default defineSchema({
     expMonth: v.optional(v.string()),
     expYear: v.optional(v.string()),
     cardHolder: v.optional(v.string()),
+    // When the customer accepted Wompi's terms and personal-data
+    // authorization (both acceptance tokens are sent with the source).
+    termsAcceptedAt: v.optional(v.number()),
   })
     .index("by_customer_id", ["customerId"])
     .index("by_user_id", ["userId"])
@@ -145,6 +148,11 @@ export default defineSchema({
     periodStart: v.optional(v.number()),
     periodEnd: v.optional(v.number()),
     wompiTransactionId: v.optional(v.string()),
+    // Earlier Wompi transactions for the same reference that a later one
+    // replaced (Web Checkout lets the payer retry a declined attempt within
+    // minutes, producing a DECLINED and an APPROVED transaction that share
+    // the reference).
+    supersededTransactionIds: v.optional(v.array(v.string())),
     paymentMethodType: v.optional(v.string()),
     failureReason: v.optional(v.string()),
     finalizedAt: v.optional(v.number()),

--- a/packages/convex-component/src/component/subscriptions.ts
+++ b/packages/convex-component/src/component/subscriptions.ts
@@ -78,6 +78,7 @@ export const create = mutation({
       customerId: args.customerId,
       userId: args.userId,
       ...args.paymentSource,
+      termsAcceptedAt: now,
     });
 
     const resumable = sameProduct.find(
@@ -85,17 +86,10 @@ export const create = mutation({
     );
 
     if (resumable) {
-      // Resume references must be deterministic — a retried call (action
-      // retry, double submit) has to land on the same pending charge instead
-      // of minting a second one. Attempts are numbered by settled charge
-      // rows: inserting the pending row doesn't move the counter, settling
-      // it does, so each declined attempt gets a fresh reference.
       const priorPayments = await ctx.db
         .query("payments")
         .withIndex("by_subscription_id", (q) => q.eq("subscriptionId", resumable._id))
         .take(200);
-      const attempt = priorPayments.filter((p) => p.status !== "pending").length;
-      const reference = subscriptionChargeReference(resumable._id, "resume", attempt);
 
       await ctx.db.patch("subscriptions", resumable._id, {
         paymentSourceId,
@@ -107,35 +101,40 @@ export const create = mutation({
         lastError: undefined,
       });
 
-      const reusable = priorPayments.find(
-        (p) => p.reference === reference && p.status === "pending",
-      );
-
-      let paymentId;
-      if (reusable) {
-        await ctx.db.patch("payments", reusable._id, {
-          amountInCents: product.amountInCents,
-          currency: product.currency,
-          description: product.name,
-          attempt,
-        });
-        paymentId = reusable._id;
-      } else {
-        paymentId = await ctx.db.insert("payments", {
-          reference,
-          kind: "subscription",
-          status: "pending",
-          customerId: args.customerId,
-          userId: args.userId,
-          productId: product._id,
-          productKey: product.key,
-          subscriptionId: resumable._id,
-          amountInCents: product.amountInCents,
-          currency: product.currency,
-          description: product.name,
-          attempt,
-        });
+      // Never mint a second charge while one is in flight. A retried call
+      // (action retry, double submit, a previous attempt that never settled)
+      // gets the same pending row back, so the caller lands on the same Wompi
+      // reference — Wompi rejects the duplicate and the existing transaction
+      // is reconciled instead of charged twice. The row is left untouched:
+      // it may already be at Wompi with these very amounts.
+      const inFlight = priorPayments.find((p) => p.status === "pending");
+      if (inFlight) {
+        return {
+          subscription: (await ctx.db.get("subscriptions", resumable._id))!,
+          payment: inFlight,
+        };
       }
+
+      // Resume references must be deterministic and fresh per settled attempt:
+      // attempts are numbered by settled charge rows, so each declined attempt
+      // gets a new reference while a crashed one is retried under its own.
+      const attempt = priorPayments.length;
+      const reference = subscriptionChargeReference(resumable._id, "resume", attempt);
+
+      const paymentId = await ctx.db.insert("payments", {
+        reference,
+        kind: "subscription",
+        status: "pending",
+        customerId: args.customerId,
+        userId: args.userId,
+        productId: product._id,
+        productKey: product.key,
+        subscriptionId: resumable._id,
+        amountInCents: product.amountInCents,
+        currency: product.currency,
+        description: product.name,
+        attempt,
+      });
 
       return {
         subscription: (await ctx.db.get("subscriptions", resumable._id))!,

--- a/packages/convex-component/src/component/subscriptions.ts
+++ b/packages/convex-component/src/component/subscriptions.ts
@@ -86,10 +86,12 @@ export const create = mutation({
     );
 
     if (resumable) {
-      const priorPayments = await ctx.db
+      const inFlight = await ctx.db
         .query("payments")
-        .withIndex("by_subscription_id", (q) => q.eq("subscriptionId", resumable._id))
-        .take(200);
+        .withIndex("by_subscription_id_status", (q) =>
+          q.eq("subscriptionId", resumable._id).eq("status", "pending"),
+        )
+        .first();
 
       await ctx.db.patch("subscriptions", resumable._id, {
         paymentSourceId,
@@ -107,7 +109,6 @@ export const create = mutation({
       // reference — Wompi rejects the duplicate and the existing transaction
       // is reconciled instead of charged twice. The row is left untouched:
       // it may already be at Wompi with these very amounts.
-      const inFlight = priorPayments.find((p) => p.status === "pending");
       if (inFlight) {
         return {
           subscription: (await ctx.db.get("subscriptions", resumable._id))!,
@@ -115,11 +116,23 @@ export const create = mutation({
         };
       }
 
-      // Resume references must be deterministic and fresh per settled attempt:
-      // attempts are numbered by settled charge rows, so each declined attempt
-      // gets a new reference while a crashed one is retried under its own.
-      const attempt = priorPayments.length;
-      const reference = subscriptionChargeReference(resumable._id, "resume", attempt);
+      // Resume references must be fresh per settled attempt: a counter on the
+      // subscription numbers them, so each declined attempt gets a new
+      // reference while a crashed one is retried under its own (above).
+      // Subscriptions from before the counter numbered resumes by row count;
+      // skip any reference such a row already holds.
+      let attempt = (resumable.resumeAttempts ?? 0) + 1;
+      let reference = subscriptionChargeReference(resumable._id, "resume", attempt);
+      while (
+        await ctx.db
+          .query("payments")
+          .withIndex("by_reference", (q) => q.eq("reference", reference))
+          .first()
+      ) {
+        attempt += 1;
+        reference = subscriptionChargeReference(resumable._id, "resume", attempt);
+      }
+      await ctx.db.patch("subscriptions", resumable._id, { resumeAttempts: attempt });
 
       const paymentId = await ctx.db.insert("payments", {
         reference,

--- a/packages/convex-component/src/react/index.ts
+++ b/packages/convex-component/src/react/index.ts
@@ -34,7 +34,7 @@ type GetConfigRef = FunctionReference<
  * `subscribe` action.
  *
  * ```tsx
- * const { tokenizeCard, acceptancePermalink, ready } =
+ * const { tokenizeCard, acceptancePermalink, personalDataAuthPermalink, ready } =
  *   useWompiTokenizer(api.wompi.getConfig);
  * const token = await tokenizeCard(card);
  * await subscribe({ productKey, token: token.id, paymentMethod: { ... } });
@@ -43,6 +43,9 @@ type GetConfigRef = FunctionReference<
 export function useWompiTokenizer(getConfig: GetConfigRef) {
   const config = useQuery(getConfig, {});
   const [acceptancePermalink, setAcceptancePermalink] = useState<string | null>(null);
+  const [personalDataAuthPermalink, setPersonalDataAuthPermalink] = useState<string | null>(
+    null,
+  );
 
   const publicKey = config?.publicKey;
   const sandbox = config?.sandbox ?? false;
@@ -57,8 +60,12 @@ export function useWompiTokenizer(getConfig: GetConfigRef) {
     let active = true;
 
     void client.merchants.getMerchant().then(([error, merchant]) => {
-      if (active && !error && merchant.presigned_acceptance) {
+      if (!active || error) return;
+      if (merchant.presigned_acceptance) {
         setAcceptancePermalink(merchant.presigned_acceptance.permalink);
+      }
+      if (merchant.presigned_personal_data_auth) {
+        setPersonalDataAuthPermalink(merchant.presigned_personal_data_auth.permalink);
       }
     });
 
@@ -93,6 +100,11 @@ export function useWompiTokenizer(getConfig: GetConfigRef) {
     config: config ?? null,
     /** Link to Wompi's terms the user accepts when saving a payment method. */
     acceptancePermalink,
+    /**
+     * Link to Wompi's personal-data authorization (habeas data). Show both
+     * links: `subscribe` sends both acceptance tokens on the user's behalf.
+     */
+    personalDataAuthPermalink,
     tokenizeCard,
   };
 }

--- a/packages/convex-component/src/react/index.ts
+++ b/packages/convex-component/src/react/index.ts
@@ -42,10 +42,14 @@ type GetConfigRef = FunctionReference<
  */
 export function useWompiTokenizer(getConfig: GetConfigRef) {
   const config = useQuery(getConfig, {});
-  const [acceptancePermalink, setAcceptancePermalink] = useState<string | null>(null);
-  const [personalDataAuthPermalink, setPersonalDataAuthPermalink] = useState<string | null>(
-    null,
-  );
+  // Links are stored with the client that fetched them, so a previous
+  // merchant's links are never shown while the new ones load or after the
+  // request fails.
+  const [links, setLinks] = useState<{
+    client: WompiClient;
+    acceptance: string | null;
+    personalDataAuth: string | null;
+  } | null>(null);
 
   const publicKey = config?.publicKey;
   const sandbox = config?.sandbox ?? false;
@@ -61,18 +65,21 @@ export function useWompiTokenizer(getConfig: GetConfigRef) {
 
     void client.merchants.getMerchant().then(([error, merchant]) => {
       if (!active || error) return;
-      if (merchant.presigned_acceptance) {
-        setAcceptancePermalink(merchant.presigned_acceptance.permalink);
-      }
-      if (merchant.presigned_personal_data_auth) {
-        setPersonalDataAuthPermalink(merchant.presigned_personal_data_auth.permalink);
-      }
+      setLinks({
+        client,
+        acceptance: merchant.presigned_acceptance?.permalink ?? null,
+        personalDataAuth: merchant.presigned_personal_data_auth?.permalink ?? null,
+      });
     });
 
     return () => {
       active = false;
     };
   }, [client]);
+
+  const currentLinks = links !== null && links.client === client ? links : null;
+  const acceptancePermalink = currentLinks?.acceptance ?? null;
+  const personalDataAuthPermalink = currentLinks?.personalDataAuth ?? null;
 
   const tokenizeCard = useCallback(
     async (card: CardInput): Promise<CardToken> => {

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -83,10 +83,12 @@ const wompi = new WompiClient({
   sandbox: true,
 });
 
-// 1. Acceptance token from the merchant.
+// 1. Acceptance tokens from the merchant — Wompi requires both consents.
 const [merchantError, merchant] = await wompi.merchants.getMerchant();
 if (merchantError) throw merchantError;
 const acceptanceToken = merchant.presigned_acceptance?.acceptance_token;
+const personalAuthToken =
+  merchant.presigned_personal_data_auth?.acceptance_token;
 if (!acceptanceToken) {
   throw new Error("Missing acceptance token in merchant response");
 }
@@ -113,6 +115,7 @@ const signature = await getSignatureKey({
 // 4. Create the transaction.
 const [error, transaction] = await wompi.transactions.createTransaction({
   acceptance_token: acceptanceToken,
+  accept_personal_auth: personalAuthToken,
   amount_in_cents: amountInCents,
   currency: "COP",
   signature,

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -70,7 +70,7 @@ console.log(response.status); // fully typed
 
 ### Creating a transaction
 
-A card transaction needs an acceptance token, a card token, and an integrity
+A card transaction needs both acceptance tokens, a card token, and an integrity
 signature:
 
 ```typescript
@@ -84,13 +84,16 @@ const wompi = new WompiClient({
 });
 
 // 1. Acceptance tokens from the merchant — Wompi requires both consents.
+//    Show `presigned_acceptance.permalink` and
+//    `presigned_personal_data_auth.permalink` to the customer and send the
+//    tokens only after they accept.
 const [merchantError, merchant] = await wompi.merchants.getMerchant();
 if (merchantError) throw merchantError;
 const acceptanceToken = merchant.presigned_acceptance?.acceptance_token;
 const personalAuthToken =
   merchant.presigned_personal_data_auth?.acceptance_token;
-if (!acceptanceToken) {
-  throw new Error("Missing acceptance token in merchant response");
+if (!acceptanceToken || !personalAuthToken) {
+  throw new Error("Missing acceptance tokens in merchant response");
 }
 
 // 2. Tokenize the card.

--- a/packages/core/skills/wompi-go-to-production/SKILL.md
+++ b/packages/core/skills/wompi-go-to-production/SKILL.md
@@ -191,10 +191,11 @@ app.post('/pay', async (c) => {
     return c.json({ error: 'Invalid amount' }, 400);
   }
 
-  // Fresh acceptance token per transaction
+  // Fresh acceptance tokens per transaction — Wompi requires both consents
   const [merchantErr, merchant] = await wompi.merchants.getMerchant();
   if (merchantErr) return c.json({ error: merchantErr.message }, 500);
   const acceptanceToken = merchant.presigned_acceptance?.acceptance_token;
+  const personalAuthToken = merchant.presigned_personal_data_auth?.acceptance_token;
   if (!acceptanceToken) return c.json({ error: 'Could not get acceptance token' }, 500);
 
   // Tokenize card
@@ -218,6 +219,7 @@ app.post('/pay', async (c) => {
   // Create transaction
   const [txnErr, txn] = await wompi.transactions.createTransaction({
     acceptance_token: acceptanceToken,
+    accept_personal_auth: personalAuthToken,
     amount_in_cents: amountInCents,
     currency: 'COP',
     signature,

--- a/packages/core/skills/wompi-go-to-production/SKILL.md
+++ b/packages/core/skills/wompi-go-to-production/SKILL.md
@@ -196,7 +196,9 @@ app.post('/pay', async (c) => {
   if (merchantErr) return c.json({ error: merchantErr.message }, 500);
   const acceptanceToken = merchant.presigned_acceptance?.acceptance_token;
   const personalAuthToken = merchant.presigned_personal_data_auth?.acceptance_token;
-  if (!acceptanceToken) return c.json({ error: 'Could not get acceptance token' }, 500);
+  if (!acceptanceToken || !personalAuthToken) {
+    return c.json({ error: 'Could not get acceptance tokens' }, 500);
+  }
 
   // Tokenize card
   const [tokenErr, token] = await wompi.tokens.tokenizeCard({

--- a/packages/core/skills/wompi-payment-sources/SKILL.md
+++ b/packages/core/skills/wompi-payment-sources/SKILL.md
@@ -36,8 +36,9 @@ const wompi = new WompiClient({
 // 1. Get both acceptance tokens
 const [merchantErr, merchant] = await wompi.merchants.getMerchant();
 if (merchantErr) throw merchantErr;
-const acceptanceToken = merchant.presigned_acceptance!.acceptance_token;
-const personalAuthToken = merchant.presigned_personal_data_auth!.acceptance_token;
+const acceptanceToken = merchant.presigned_acceptance?.acceptance_token;
+const personalAuthToken = merchant.presigned_personal_data_auth?.acceptance_token;
+if (!acceptanceToken || !personalAuthToken) throw new Error('Missing acceptance tokens');
 
 // 2. Tokenize the card
 const [tokenErr, token] = await wompi.tokens.tokenizeCard({
@@ -116,8 +117,9 @@ const signature = await getSignatureKey({
 
 const [merchantErr, merchant] = await wompi.merchants.getMerchant();
 if (merchantErr) throw merchantErr;
-const acceptanceToken = merchant.presigned_acceptance!.acceptance_token;
-const personalAuthToken = merchant.presigned_personal_data_auth!.acceptance_token;
+const acceptanceToken = merchant.presigned_acceptance?.acceptance_token;
+const personalAuthToken = merchant.presigned_personal_data_auth?.acceptance_token;
+if (!acceptanceToken || !personalAuthToken) throw new Error('Missing acceptance tokens');
 
 const [error, txn] = await wompi.transactions.createTransaction({
   acceptance_token: acceptanceToken,
@@ -163,7 +165,7 @@ Source: `packages/core/src/client/payment-sources/index.ts`
 
 ---
 
-### HIGH Omitting `acceptance_token` when creating a payment source
+### HIGH Omitting the acceptance tokens when creating a payment source
 
 Wrong:
 
@@ -172,7 +174,7 @@ await wompi.paymentSources.createPaymentSource({
   type: 'CARD',
   token: cardToken.id,
   customer_email: 'user@example.com',
-  // acceptance_token missing — Zod validation fails before HTTP call
+  // acceptance_token and accept_personal_auth missing — Zod validation fails before HTTP call
 });
 ```
 
@@ -181,8 +183,9 @@ Correct:
 ```typescript
 const [merchantErr, merchant] = await wompi.merchants.getMerchant();
 if (merchantErr) throw merchantErr;
-const acceptanceToken = merchant.presigned_acceptance!.acceptance_token;
-const personalAuthToken = merchant.presigned_personal_data_auth!.acceptance_token;
+const acceptanceToken = merchant.presigned_acceptance?.acceptance_token;
+const personalAuthToken = merchant.presigned_personal_data_auth?.acceptance_token;
+if (!acceptanceToken || !personalAuthToken) throw new Error('Missing acceptance tokens');
 
 await wompi.paymentSources.createPaymentSource({
   type: 'CARD',
@@ -193,7 +196,7 @@ await wompi.paymentSources.createPaymentSource({
 });
 ```
 
-`acceptance_token` is required in `createPaymentSource` — same merchant acceptance token used for transactions. Send `accept_personal_auth` (from `presigned_personal_data_auth`) with it. Fetch both fresh before each call.
+Both `acceptance_token` and `accept_personal_auth` are required in `createPaymentSource` — the same merchant tokens used for transactions. Fetch both fresh before each call, show the two permalinks (`presigned_acceptance.permalink`, `presigned_personal_data_auth.permalink`) to the customer, and send the tokens only after they accept.
 
 Source: `packages/core/src/schemas.ts` — `CreatePaymentSourceInputSchema`
 

--- a/packages/core/skills/wompi-payment-sources/SKILL.md
+++ b/packages/core/skills/wompi-payment-sources/SKILL.md
@@ -2,8 +2,9 @@
 name: wompi-payment-sources
 description: >
   Create and retrieve reusable Wompi payment sources using @pulgueta/wompi.
-  Covers createPaymentSource (CARD or NEQUI, requires acceptance_token and
-  privateKey), getPaymentSource, PaymentSourceStatus (AVAILABLE/PENDING),
+  Covers createPaymentSource (CARD, NEQUI, DAVIPLATA or BANCOLOMBIA_TRANSFER;
+  requires acceptance_token, accept_personal_auth and privateKey),
+  getPaymentSource, PaymentSourceStatus (AVAILABLE/PENDING/VOIDED),
   and charging a customer via payment_source_id in createTransaction.
   Load when building recurring billing, saved payment methods, or subscription flows.
 type: core
@@ -32,10 +33,11 @@ const wompi = new WompiClient({
   sandbox: process.env.NODE_ENV !== 'production',
 });
 
-// 1. Get acceptance token
+// 1. Get both acceptance tokens
 const [merchantErr, merchant] = await wompi.merchants.getMerchant();
 if (merchantErr) throw merchantErr;
 const acceptanceToken = merchant.presigned_acceptance!.acceptance_token;
+const personalAuthToken = merchant.presigned_personal_data_auth!.acceptance_token;
 
 // 2. Tokenize the card
 const [tokenErr, token] = await wompi.tokens.tokenizeCard({
@@ -52,6 +54,7 @@ const [sourceErr, source] = await wompi.paymentSources.createPaymentSource({
   type: 'CARD',
   token: token.id,
   acceptance_token: acceptanceToken,
+  accept_personal_auth: personalAuthToken,
   customer_email: 'maria@example.com',
 });
 if (sourceErr) throw sourceErr;
@@ -75,6 +78,7 @@ const [sourceErr, source] = await wompi.paymentSources.createPaymentSource({
   type: 'NEQUI',
   token: nequiToken.id,
   acceptance_token: acceptanceToken,
+  accept_personal_auth: personalAuthToken,
   customer_email: 'user@example.com',
 });
 if (sourceErr) throw sourceErr;
@@ -113,9 +117,11 @@ const signature = await getSignatureKey({
 const [merchantErr, merchant] = await wompi.merchants.getMerchant();
 if (merchantErr) throw merchantErr;
 const acceptanceToken = merchant.presigned_acceptance!.acceptance_token;
+const personalAuthToken = merchant.presigned_personal_data_auth!.acceptance_token;
 
 const [error, txn] = await wompi.transactions.createTransaction({
   acceptance_token: acceptanceToken,
+  accept_personal_auth: personalAuthToken,
   amount_in_cents: amountInCents,
   currency: 'COP',
   signature,
@@ -176,16 +182,18 @@ Correct:
 const [merchantErr, merchant] = await wompi.merchants.getMerchant();
 if (merchantErr) throw merchantErr;
 const acceptanceToken = merchant.presigned_acceptance!.acceptance_token;
+const personalAuthToken = merchant.presigned_personal_data_auth!.acceptance_token;
 
 await wompi.paymentSources.createPaymentSource({
   type: 'CARD',
   token: cardToken.id,
   customer_email: 'user@example.com',
   acceptance_token: acceptanceToken,
+  accept_personal_auth: personalAuthToken,
 });
 ```
 
-`acceptance_token` is required in `createPaymentSource` — same merchant acceptance token used for transactions. Fetch it fresh before each call.
+`acceptance_token` is required in `createPaymentSource` — same merchant acceptance token used for transactions. Send `accept_personal_auth` (from `presigned_personal_data_auth`) with it. Fetch both fresh before each call.
 
 Source: `packages/core/src/schemas.ts` — `CreatePaymentSourceInputSchema`
 

--- a/packages/core/skills/wompi-server-integration/SKILL.md
+++ b/packages/core/skills/wompi-server-integration/SKILL.md
@@ -44,10 +44,11 @@ const wompi = new WompiClient({
 app.post('/checkout', zValidator('json', TokenizeCardInputSchema), async (c) => {
   const cardInput = c.req.valid('json');
 
-  // 1. Acceptance token
+  // 1. Acceptance tokens
   const [merchantErr, merchant] = await wompi.merchants.getMerchant();
   if (merchantErr) return c.json({ error: merchantErr.message }, 500);
   const acceptanceToken = merchant.presigned_acceptance!.acceptance_token;
+  const personalAuthToken = merchant.presigned_personal_data_auth!.acceptance_token;
 
   // 2. Tokenize
   const [tokenErr, token] = await wompi.tokens.tokenizeCard(cardInput);
@@ -65,6 +66,7 @@ app.post('/checkout', zValidator('json', TokenizeCardInputSchema), async (c) => 
   // 4. Create transaction
   const [txnErr, txn] = await wompi.transactions.createTransaction({
     acceptance_token: acceptanceToken,
+    accept_personal_auth: personalAuthToken,
     amount_in_cents: amountInCents,
     currency: 'COP',
     signature,
@@ -104,6 +106,7 @@ new Elysia()
     const [merchantErr, merchant] = await wompi.merchants.getMerchant();
     if (merchantErr) return error(500, merchantErr.message);
     const acceptanceToken = merchant.presigned_acceptance!.acceptance_token;
+    const personalAuthToken = merchant.presigned_personal_data_auth!.acceptance_token;
 
     const [tokenErr, token] = await wompi.tokens.tokenizeCard(body);
     if (tokenErr) return error(422, tokenErr.message);
@@ -118,6 +121,7 @@ new Elysia()
 
     const [txnErr, txn] = await wompi.transactions.createTransaction({
       acceptance_token: acceptanceToken,
+      accept_personal_auth: personalAuthToken,
       amount_in_cents: amountInCents,
       currency: 'COP',
       signature,

--- a/packages/core/skills/wompi-server-integration/SKILL.md
+++ b/packages/core/skills/wompi-server-integration/SKILL.md
@@ -47,8 +47,11 @@ app.post('/checkout', zValidator('json', TokenizeCardInputSchema), async (c) => 
   // 1. Acceptance tokens
   const [merchantErr, merchant] = await wompi.merchants.getMerchant();
   if (merchantErr) return c.json({ error: merchantErr.message }, 500);
-  const acceptanceToken = merchant.presigned_acceptance!.acceptance_token;
-  const personalAuthToken = merchant.presigned_personal_data_auth!.acceptance_token;
+  const acceptanceToken = merchant.presigned_acceptance?.acceptance_token;
+  const personalAuthToken = merchant.presigned_personal_data_auth?.acceptance_token;
+  if (!acceptanceToken || !personalAuthToken) {
+    return c.json({ error: 'Merchant has no acceptance tokens' }, 500);
+  }
 
   // 2. Tokenize
   const [tokenErr, token] = await wompi.tokens.tokenizeCard(cardInput);
@@ -105,8 +108,11 @@ new Elysia()
   .post('/checkout', async ({ body, error }) => {
     const [merchantErr, merchant] = await wompi.merchants.getMerchant();
     if (merchantErr) return error(500, merchantErr.message);
-    const acceptanceToken = merchant.presigned_acceptance!.acceptance_token;
-    const personalAuthToken = merchant.presigned_personal_data_auth!.acceptance_token;
+    const acceptanceToken = merchant.presigned_acceptance?.acceptance_token;
+    const personalAuthToken = merchant.presigned_personal_data_auth?.acceptance_token;
+    if (!acceptanceToken || !personalAuthToken) {
+      return error(500, 'Merchant has no acceptance tokens');
+    }
 
     const [tokenErr, token] = await wompi.tokens.tokenizeCard(body);
     if (tokenErr) return error(422, tokenErr.message);

--- a/packages/core/skills/wompi-transactions/SKILL.md
+++ b/packages/core/skills/wompi-transactions/SKILL.md
@@ -2,7 +2,8 @@
 name: wompi-transactions
 description: >
   Full Wompi transaction lifecycle using @pulgueta/wompi. Covers getMerchant
-  for acceptance_token, tokenizeCard and tokenizeNequi, getSignatureKey for
+  for acceptance_token and accept_personal_auth, tokenizeCard and
+  tokenizeNequi, getSignatureKey for
   SHA-256 integrity signature (amountInCents as-is, never multiplied),
   createTransaction with payment_method or payment_source_id, getTransaction,
   listTransactions with from_date/until_date/status filters, voidTransaction
@@ -39,10 +40,11 @@ const wompi = new WompiClient({
   sandbox: process.env.NODE_ENV !== 'production',
 });
 
-// 1. Fresh acceptance token — fetch for each transaction
+// 1. Fresh acceptance tokens — fetch both for each transaction
 const [merchantErr, merchant] = await wompi.merchants.getMerchant();
 if (merchantErr) throw merchantErr;
 const acceptanceToken = merchant.presigned_acceptance?.acceptance_token;
+const personalAuthToken = merchant.presigned_personal_data_auth?.acceptance_token;
 if (!acceptanceToken) throw new Error('Missing acceptance token');
 
 // 2. Tokenize the card
@@ -67,6 +69,7 @@ const signature = await getSignatureKey({
 // 4. Create the transaction
 const [error, txn] = await wompi.transactions.createTransaction({
   acceptance_token: acceptanceToken,
+  accept_personal_auth: personalAuthToken,
   amount_in_cents: amountInCents,
   currency: 'COP',
   signature,
@@ -230,10 +233,11 @@ await wompi.transactions.createTransaction({ acceptance_token: acceptanceToken, 
 Correct:
 
 ```typescript
-// Fetch a fresh token for each transaction
+// Fetch fresh tokens for each transaction
 const [merchantErr, merchant] = await wompi.merchants.getMerchant();
 if (merchantErr) throw merchantErr;
 const acceptanceToken = merchant.presigned_acceptance?.acceptance_token;
+const personalAuthToken = merchant.presigned_personal_data_auth?.acceptance_token;
 if (!acceptanceToken) throw new Error('Missing acceptance token');
 ```
 

--- a/packages/core/skills/wompi-transactions/SKILL.md
+++ b/packages/core/skills/wompi-transactions/SKILL.md
@@ -40,12 +40,14 @@ const wompi = new WompiClient({
   sandbox: process.env.NODE_ENV !== 'production',
 });
 
-// 1. Fresh acceptance tokens — fetch both for each transaction
+// 1. Fresh acceptance tokens — fetch both for each transaction. Show the two
+//    permalinks (presigned_acceptance.permalink, presigned_personal_data_auth.permalink)
+//    and send the tokens only after the customer accepts.
 const [merchantErr, merchant] = await wompi.merchants.getMerchant();
 if (merchantErr) throw merchantErr;
 const acceptanceToken = merchant.presigned_acceptance?.acceptance_token;
 const personalAuthToken = merchant.presigned_personal_data_auth?.acceptance_token;
-if (!acceptanceToken) throw new Error('Missing acceptance token');
+if (!acceptanceToken || !personalAuthToken) throw new Error('Missing acceptance tokens');
 
 // 2. Tokenize the card
 const [tokenErr, token] = await wompi.tokens.tokenizeCard({
@@ -238,7 +240,7 @@ const [merchantErr, merchant] = await wompi.merchants.getMerchant();
 if (merchantErr) throw merchantErr;
 const acceptanceToken = merchant.presigned_acceptance?.acceptance_token;
 const personalAuthToken = merchant.presigned_personal_data_auth?.acceptance_token;
-if (!acceptanceToken) throw new Error('Missing acceptance token');
+if (!acceptanceToken || !personalAuthToken) throw new Error('Missing acceptance tokens');
 ```
 
 Source: `packages/core/src/client/merchants/index.ts`, README

--- a/packages/core/src/payments-schemas.ts
+++ b/packages/core/src/payments-schemas.ts
@@ -97,7 +97,8 @@ export const TaxSchema = z.union([TaxByAmountSchema, TaxByPercentageSchema]);
  *
  * Wompi requires two acceptance tokens: `acceptance_token` (from
  * `merchant.presigned_acceptance`) and `accept_personal_auth` (from
- * `merchant.presigned_personal_data_auth`).
+ * `merchant.presigned_personal_data_auth`). Both are required here, so a
+ * request without them is rejected locally before anything is sent.
  *
  * The object is `.loose()` so any field Wompi documents but the SDK does not
  * name still reaches the API — stripping it would silently change the request.
@@ -105,7 +106,7 @@ export const TaxSchema = z.union([TaxByAmountSchema, TaxByPercentageSchema]);
 export const CreateTransactionInputSchema = z
   .object({
     acceptance_token: z.string(),
-    accept_personal_auth: z.string().optional(),
+    accept_personal_auth: z.string(),
     amount_in_cents: z.number().int().min(1).max(MAX_AMOUNT_IN_CENTS),
     currency: CurrencySchema,
     signature: z.string(),
@@ -267,7 +268,7 @@ export const CreatePaymentSourceInputSchema = z
     type: PaymentSourceTypeSchema,
     token: z.string(),
     acceptance_token: z.string(),
-    accept_personal_auth: z.string().optional(),
+    accept_personal_auth: z.string(),
     customer_email: z.email(),
     payment_description: z.string().optional(),
   })

--- a/packages/core/src/payments-schemas.ts
+++ b/packages/core/src/payments-schemas.ts
@@ -29,9 +29,14 @@ export const TransactionStatusSchema = z.enum([
   "VOIDED",
 ]);
 
-export const PaymentSourceTypeSchema = z.enum(["CARD", "NEQUI"]);
+export const PaymentSourceTypeSchema = z.enum([
+  "CARD",
+  "NEQUI",
+  "DAVIPLATA",
+  "BANCOLOMBIA_TRANSFER",
+]);
 
-export const PaymentSourceStatusSchema = z.enum(["AVAILABLE", "PENDING"]);
+export const PaymentSourceStatusSchema = z.enum(["AVAILABLE", "PENDING", "VOIDED"]);
 
 export const NequiTokenStatusSchema = z.enum(["PENDING", "APPROVED", "DECLINED"]);
 
@@ -41,7 +46,7 @@ export const TaxTypeSchema = z.enum(["VAT", "CONSUMPTION"]);
 
 export const OrderDirectionSchema = z.enum(["DESC", "ASC"]);
 
-export const AcceptanceTypeSchema = z.literal("END_USER_POLICY");
+export const AcceptanceTypeSchema = z.enum(["END_USER_POLICY", "PERSONAL_DATA_AUTH"]);
 
 export const MerchantLegalIdTypeSchema = z.enum(["NIT", "CC"]);
 
@@ -75,21 +80,50 @@ export const TransactionPaymentMethodSchema = z
   })
   .loose();
 
+export const TaxByAmountSchema = z.object({
+  type: TaxTypeSchema,
+  amount_in_cents: z.number().int().min(1).max(MAX_AMOUNT_IN_CENTS),
+});
+
+export const TaxByPercentageSchema = z.object({
+  type: TaxTypeSchema,
+  percentage: z.number().int().min(1).max(50),
+});
+
+export const TaxSchema = z.union([TaxByAmountSchema, TaxByPercentageSchema]);
+
+/**
+ * `POST /transactions` payload.
+ *
+ * Wompi requires two acceptance tokens: `acceptance_token` (from
+ * `merchant.presigned_acceptance`) and `accept_personal_auth` (from
+ * `merchant.presigned_personal_data_auth`).
+ *
+ * The object is `.loose()` so any field Wompi documents but the SDK does not
+ * name still reaches the API — stripping it would silently change the request.
+ */
 export const CreateTransactionInputSchema = z
   .object({
     acceptance_token: z.string(),
+    accept_personal_auth: z.string().optional(),
     amount_in_cents: z.number().int().min(1).max(MAX_AMOUNT_IN_CENTS),
     currency: CurrencySchema,
     signature: z.string(),
     customer_email: z.email(),
     payment_method: TransactionPaymentMethodSchema.optional(),
+    payment_method_type: z.string().optional(),
     payment_source_id: z.number().int().positive().optional(),
     redirect_url: z.url().optional(),
     reference: z.string(),
     expiration_time: z.string().optional(),
     customer_data: CustomerDataSchema.optional(),
     shipping_address: ShippingAddressSchema.optional(),
+    taxes: z.array(TaxSchema).optional(),
+    ip: z.string().optional(),
+    recurrent: z.boolean().optional(),
+    parent_transaction_id: z.string().optional(),
   })
+  .loose()
   .refine((data) => data.payment_method !== undefined || data.payment_source_id !== undefined, {
     message: "Provide payment_method, payment_source_id, or both",
   });
@@ -195,28 +229,49 @@ export const NequiTokenSchema = z
   })
   .loose();
 
-export const PaymentSourcePublicDataSchema = z.object({
-  type: PaymentSourceTypeSchema,
-  phone_number: z.string().optional(),
-});
+export const PaymentSourcePublicDataSchema = z
+  .object({
+    type: z.string(),
+    phone_number: z.string().optional(),
+  })
+  .loose();
 
+/**
+ * Response shape of a payment source.
+ *
+ * `type` and `status` stay plain strings: Wompi adds source kinds and states over
+ * time, and a `200` must never surface as a validation error. Use
+ * {@link PaymentSourceTypeSchema} / {@link PaymentSourceStatusSchema} (and their
+ * `PaymentSourceType` / `PaymentSourceStatus` types) to narrow on the known values.
+ */
 export const PaymentSourceSchema = z
   .object({
     id: z.number().int(),
-    status: PaymentSourceStatusSchema,
-    type: PaymentSourceTypeSchema.optional(),
+    status: z.string(),
+    type: z.string().optional(),
     token: z.string().optional(),
     customer_email: z.string().optional(),
     public_data: PaymentSourcePublicDataSchema.optional(),
   })
   .loose();
 
-export const CreatePaymentSourceInputSchema = z.object({
-  type: PaymentSourceTypeSchema,
-  token: z.string(),
-  acceptance_token: z.string(),
-  customer_email: z.email(),
-});
+/**
+ * `POST /payment_sources` payload.
+ *
+ * Like a transaction, a payment source needs both acceptance tokens:
+ * `acceptance_token` and `accept_personal_auth`. `.loose()` for the same reason —
+ * documented fields the SDK does not name must still reach Wompi.
+ */
+export const CreatePaymentSourceInputSchema = z
+  .object({
+    type: PaymentSourceTypeSchema,
+    token: z.string(),
+    acceptance_token: z.string(),
+    accept_personal_auth: z.string().optional(),
+    customer_email: z.email(),
+    payment_description: z.string().optional(),
+  })
+  .loose();
 
 export const CustomerReferenceSchema = z.object({
   label: z.string().max(24),
@@ -226,18 +281,6 @@ export const CustomerReferenceSchema = z.object({
 export const PaymentLinkCustomerDataSchema = z.object({
   customer_references: z.array(CustomerReferenceSchema).max(2).optional(),
 });
-
-export const TaxByAmountSchema = z.object({
-  type: TaxTypeSchema,
-  amount_in_cents: z.number().int().min(1).max(MAX_AMOUNT_IN_CENTS),
-});
-
-export const TaxByPercentageSchema = z.object({
-  type: TaxTypeSchema,
-  percentage: z.number().int().min(1).max(50),
-});
-
-export const TaxSchema = z.union([TaxByAmountSchema, TaxByPercentageSchema]);
 
 export const CreatePaymentLinkInputSchema = z.object({
   name: z.string(),
@@ -318,6 +361,7 @@ export const MerchantSchema = z
     accepted_payment_methods: z.array(z.string()).optional(),
     accepted_currencies: z.array(CurrencySchema).optional(),
     presigned_acceptance: PresignedAcceptanceSchema.optional(),
+    presigned_personal_data_auth: PresignedAcceptanceSchema.optional(),
   })
   .loose();
 

--- a/packages/core/test/integration/read.test.ts
+++ b/packages/core/test/integration/read.test.ts
@@ -26,11 +26,12 @@ const sandboxClient = () =>
   });
 
 describe.skipIf(!publicKey)("sandbox · read-only endpoints", () => {
-  it("getMerchant returns the presigned acceptance token", async () => {
+  it("getMerchant returns both presigned acceptance tokens", async () => {
     const [error, merchant] = await sandboxClient().merchants.getMerchant();
 
     expect(error).toBeNull();
     expect(merchant?.presigned_acceptance?.acceptance_token).toBeTruthy();
+    expect(merchant?.presigned_personal_data_auth?.acceptance_token).toBeTruthy();
   });
 
   it("getFinancialInstitutions returns the PSE bank list", async () => {

--- a/packages/core/test/integration/transactions.test.ts
+++ b/packages/core/test/integration/transactions.test.ts
@@ -29,11 +29,13 @@ describe.skipIf(!canRun)("sandbox · transaction lifecycle", () => {
   it("creates a transaction with a getSignatureKey signature, reads it, then voids it", async () => {
     const wompi = sandboxClient();
 
-    // 1. Acceptance token from the merchant.
+    // 1. Both acceptance tokens from the merchant.
     const [merchantError, merchant] = await wompi.merchants.getMerchant();
     expect(merchantError).toBeNull();
     const acceptanceToken = merchant?.presigned_acceptance?.acceptance_token;
+    const personalAuthToken = merchant?.presigned_personal_data_auth?.acceptance_token;
     expect(acceptanceToken).toBeTruthy();
+    expect(personalAuthToken).toBeTruthy();
 
     // 2. Tokenize the approved test card.
     const [tokenError, token] = await wompi.tokens.tokenizeCard({
@@ -58,6 +60,7 @@ describe.skipIf(!canRun)("sandbox · transaction lifecycle", () => {
     // 4. Create the transaction.
     const [createError, created] = await wompi.transactions.createTransaction({
       acceptance_token: acceptanceToken,
+      accept_personal_auth: personalAuthToken,
       amount_in_cents: amountInCents,
       currency: "COP",
       signature,

--- a/packages/core/test/merchants.test.ts
+++ b/packages/core/test/merchants.test.ts
@@ -22,6 +22,11 @@ const MERCHANT_RESPONSE = {
       permalink: "https://wompi.co/terms",
       type: "END_USER_POLICY",
     },
+    presigned_personal_data_auth: {
+      acceptance_token: "eyJwZXJz...",
+      permalink: "https://wompi.co/personal-data",
+      type: "PERSONAL_DATA_AUTH",
+    },
   },
 };
 
@@ -56,6 +61,26 @@ describe("Merchants", () => {
       const [url, options] = mockFetch.mock.calls[0]!;
       expect(url).toContain(`/merchants/${PUBLIC_KEY}`);
       expect(options.method).toBe("GET");
+    });
+
+    it("should expose both presigned acceptance tokens", async () => {
+      const merchants = makeClient();
+
+      mockFetch.mockResolvedValueOnce(okJson(MERCHANT_RESPONSE));
+
+      const [error, data] = await merchants.getMerchant();
+
+      expect(error).toBeNull();
+      expect(data!.presigned_acceptance).toEqual({
+        acceptance_token: "eyJhb...",
+        permalink: "https://wompi.co/terms",
+        type: "END_USER_POLICY",
+      });
+      expect(data!.presigned_personal_data_auth).toEqual({
+        acceptance_token: "eyJwZXJz...",
+        permalink: "https://wompi.co/personal-data",
+        type: "PERSONAL_DATA_AUTH",
+      });
     });
 
     it("should accept payment methods outside the strict enum", async () => {

--- a/packages/core/test/payment-sources.test.ts
+++ b/packages/core/test/payment-sources.test.ts
@@ -65,10 +65,10 @@ describe("PaymentSources", () => {
         okJson({
           data: {
             id: 543,
-            type: "DAVIPLATA",
-            status: "VOIDED",
+            type: "FUTURE_SOURCE_TYPE",
+            status: "FUTURE_STATUS",
             customer_email: "juan@example.com",
-            public_data: { type: "DAVIPLATA", phone_number: "3991111111" },
+            public_data: { type: "FUTURE_SOURCE_TYPE", phone_number: "3991111111" },
           },
         })
       );
@@ -76,9 +76,9 @@ describe("PaymentSources", () => {
       const [error, data] = await sources.getPaymentSource(543);
 
       expect(error).toBeNull();
-      expect(data!.type).toBe("DAVIPLATA");
-      expect(data!.status).toBe("VOIDED");
-      expect(data!.public_data!.type).toBe("DAVIPLATA");
+      expect(data!.type).toBe("FUTURE_SOURCE_TYPE");
+      expect(data!.status).toBe("FUTURE_STATUS");
+      expect(data!.public_data!.type).toBe("FUTURE_SOURCE_TYPE");
     });
   });
 
@@ -89,6 +89,7 @@ describe("PaymentSources", () => {
         type: "CARD",
         token: "tok_test_abc",
         acceptance_token: "eyJhb...",
+        accept_personal_auth: "eyJwZXJz...",
         customer_email: "test@example.com",
       };
 
@@ -123,12 +124,29 @@ describe("PaymentSources", () => {
         type: "NEQUI",
         token: "nequi_test_abc",
         acceptance_token: "eyJhb...",
+        accept_personal_auth: "eyJwZXJz...",
         customer_email: "test@example.com",
       });
 
       expect(data).toBeNull();
       expect(error).toBeInstanceOf(WompiError);
       expect(error!.message).toContain("Private key is required");
+    });
+
+    it("should reject a missing accept_personal_auth before any request is sent", async () => {
+      const sources = makeClient(PRIVATE_KEY);
+
+      const [error, data] = await sources.createPaymentSource({
+        type: "CARD",
+        token: "tok_test_abc",
+        acceptance_token: "eyJhb...",
+        customer_email: "test@example.com",
+      });
+
+      expect(data).toBeNull();
+      expect(error).toBeInstanceOf(WompiError);
+      expect(error!.message).toContain("accept_personal_auth");
+      expect(mockFetch).not.toHaveBeenCalled();
     });
 
     it("should forward the second acceptance token and payment_description", async () => {

--- a/packages/core/test/payment-sources.test.ts
+++ b/packages/core/test/payment-sources.test.ts
@@ -57,6 +57,29 @@ describe("PaymentSources", () => {
       expect(error).toBeInstanceOf(WompiError);
       expect(error!.message).toContain("Private key is required");
     });
+
+    it("should accept a type and status outside the known enums", async () => {
+      const sources = makeClient(PRIVATE_KEY);
+
+      mockFetch.mockResolvedValueOnce(
+        okJson({
+          data: {
+            id: 543,
+            type: "DAVIPLATA",
+            status: "VOIDED",
+            customer_email: "juan@example.com",
+            public_data: { type: "DAVIPLATA", phone_number: "3991111111" },
+          },
+        })
+      );
+
+      const [error, data] = await sources.getPaymentSource(543);
+
+      expect(error).toBeNull();
+      expect(data!.type).toBe("DAVIPLATA");
+      expect(data!.status).toBe("VOIDED");
+      expect(data!.public_data!.type).toBe("DAVIPLATA");
+    });
   });
 
   describe("createPaymentSource", () => {
@@ -106,6 +129,51 @@ describe("PaymentSources", () => {
       expect(data).toBeNull();
       expect(error).toBeInstanceOf(WompiError);
       expect(error!.message).toContain("Private key is required");
+    });
+
+    it("should forward the second acceptance token and payment_description", async () => {
+      const sources = makeClient(PRIVATE_KEY);
+
+      mockFetch.mockResolvedValueOnce(
+        okJson({ data: { id: 999, type: "CARD", status: "AVAILABLE" } })
+      );
+
+      const [error] = await sources.createPaymentSource({
+        type: "CARD",
+        token: "tok_test_abc",
+        acceptance_token: "eyJhb...",
+        accept_personal_auth: "eyJwZXJz...",
+        customer_email: "test@example.com",
+        payment_description: "Suscripcion mensual",
+      });
+
+      expect(error).toBeNull();
+
+      const [, options] = mockFetch.mock.calls[0]!;
+      expect(JSON.parse(options.body)).toMatchObject({
+        acceptance_token: "eyJhb...",
+        accept_personal_auth: "eyJwZXJz...",
+        payment_description: "Suscripcion mensual",
+      });
+    });
+
+    it("should accept BANCOLOMBIA_TRANSFER as a source type", async () => {
+      const sources = makeClient(PRIVATE_KEY);
+
+      mockFetch.mockResolvedValueOnce(
+        okJson({ data: { id: 1001, type: "BANCOLOMBIA_TRANSFER", status: "PENDING" } })
+      );
+
+      const [error, data] = await sources.createPaymentSource({
+        type: "BANCOLOMBIA_TRANSFER",
+        token: "tok_bancolombia_abc",
+        acceptance_token: "eyJhb...",
+        accept_personal_auth: "eyJwZXJz...",
+        customer_email: "test@example.com",
+      });
+
+      expect(error).toBeNull();
+      expect(data!.type).toBe("BANCOLOMBIA_TRANSFER");
     });
 
     it("should return [error, null] on invalid input", async () => {

--- a/packages/core/test/schemas.test.ts
+++ b/packages/core/test/schemas.test.ts
@@ -174,6 +174,7 @@ describe("PaymentMethodTypeSchema (strict input filter)", () => {
 describe("CreateTransactionInputSchema (strict input)", () => {
   const base = {
     acceptance_token: "acc_tok",
+    accept_personal_auth: "personal_auth_tok",
     amount_in_cents: 2_490_000,
     currency: "COP",
     signature: "sig",
@@ -213,10 +214,23 @@ describe("CreateTransactionInputSchema (strict input)", () => {
     expect(CreateTransactionInputSchema.safeParse(base).success).toBe(false);
   });
 
+  it("requires both acceptance tokens", () => {
+    const { acceptance_token: _acceptance, ...withoutAcceptance } = base;
+    const { accept_personal_auth: _personal, ...withoutPersonal } = base;
+
+    expect(
+      CreateTransactionInputSchema.safeParse({ ...withoutAcceptance, payment_method: { type: "CARD" } })
+        .success
+    ).toBe(false);
+    expect(
+      CreateTransactionInputSchema.safeParse({ ...withoutPersonal, payment_method: { type: "CARD" } })
+        .success
+    ).toBe(false);
+  });
+
   it("keeps the second acceptance token and the optional documented fields", () => {
     const result = CreateTransactionInputSchema.parse({
       ...base,
-      accept_personal_auth: "personal_auth_tok",
       payment_method: { type: "CARD" },
       taxes: [{ type: "VAT", amount_in_cents: 478_000 }],
       ip: "190.0.0.1",

--- a/packages/core/test/schemas.test.ts
+++ b/packages/core/test/schemas.test.ts
@@ -213,6 +213,38 @@ describe("CreateTransactionInputSchema (strict input)", () => {
     expect(CreateTransactionInputSchema.safeParse(base).success).toBe(false);
   });
 
+  it("keeps the second acceptance token and the optional documented fields", () => {
+    const result = CreateTransactionInputSchema.parse({
+      ...base,
+      accept_personal_auth: "personal_auth_tok",
+      payment_method: { type: "CARD" },
+      taxes: [{ type: "VAT", amount_in_cents: 478_000 }],
+      ip: "190.0.0.1",
+      recurrent: true,
+      parent_transaction_id: "txn-parent",
+      payment_method_type: "CARD",
+    });
+
+    expect(result).toMatchObject({
+      accept_personal_auth: "personal_auth_tok",
+      taxes: [{ type: "VAT", amount_in_cents: 478_000 }],
+      ip: "190.0.0.1",
+      recurrent: true,
+      parent_transaction_id: "txn-parent",
+      payment_method_type: "CARD",
+    });
+  });
+
+  it("keeps unknown fields instead of stripping them — the payload is loose", () => {
+    const result = CreateTransactionInputSchema.parse({
+      ...base,
+      payment_method: { type: "CARD" },
+      future_field_wompi_added: "keep me",
+    });
+
+    expect(result).toHaveProperty("future_field_wompi_added", "keep me");
+  });
+
   it("rejects an amount_in_cents above Wompi's maximum", () => {
     expect(
       CreateTransactionInputSchema.safeParse({

--- a/packages/core/test/transactions.test.ts
+++ b/packages/core/test/transactions.test.ts
@@ -160,6 +160,7 @@ describe("Transactions", () => {
       const transactions = makeClient(PRIVATE_KEY);
       const input = {
         acceptance_token: "eyJhb...",
+        accept_personal_auth: "eyJwZXJz...",
         amount_in_cents: 3000000,
         currency: "COP",
         signature: "sig_123",
@@ -185,6 +186,7 @@ describe("Transactions", () => {
 
       const [error] = await transactions.createTransaction({
         acceptance_token: "eyJhb...",
+        accept_personal_auth: "eyJwZXJz...",
         amount_in_cents: 3000000,
         currency: "COP",
         signature: "sig_123",
@@ -203,6 +205,7 @@ describe("Transactions", () => {
 
       const [error, data] = await transactions.createTransaction({
         acceptance_token: "eyJhb...",
+        accept_personal_auth: "eyJwZXJz...",
         amount_in_cents: 3000000,
         currency: "COP",
         signature: "sig_123",
@@ -220,6 +223,7 @@ describe("Transactions", () => {
 
       const [error, data] = await transactions.createTransaction({
         acceptance_token: "eyJhb...",
+        accept_personal_auth: "eyJwZXJz...",
         amount_in_cents: 3000000,
         currency: "COP",
         signature: "sig_123",
@@ -244,6 +248,7 @@ describe("Transactions", () => {
 
       const [error, data] = await transactions.createTransaction({
         acceptance_token: "eyJhb...",
+        accept_personal_auth: "eyJwZXJz...",
         amount_in_cents: 3000000,
         currency: "COP",
         signature: "sig_123",
@@ -262,6 +267,25 @@ describe("Transactions", () => {
         payment_source_id: 1234,
       });
       expect(init.headers.Authorization).toBe(`Bearer ${PRIVATE_KEY}`);
+    });
+
+    it("should reject a missing accept_personal_auth before any request is sent", async () => {
+      const transactions = makeClient(PRIVATE_KEY);
+
+      const [error, data] = await transactions.createTransaction({
+        acceptance_token: "eyJhb...",
+        amount_in_cents: 3000000,
+        currency: "COP",
+        signature: "sig_123",
+        customer_email: "test@example.com",
+        reference: "ref-123",
+        payment_method: { type: "CARD", token: "tok_123", installments: 1 },
+      });
+
+      expect(data).toBeNull();
+      expect(error).toBeInstanceOf(WompiError);
+      expect(error!.message).toContain("accept_personal_auth");
+      expect(mockFetch).not.toHaveBeenCalled();
     });
 
     it("should forward the second acceptance token and the optional documented fields", async () => {
@@ -304,6 +328,7 @@ describe("Transactions", () => {
 
       const [error] = await transactions.createTransaction({
         acceptance_token: "eyJhb...",
+        accept_personal_auth: "eyJwZXJz...",
         amount_in_cents: 3000000,
         currency: "COP",
         signature: "sig_123",

--- a/packages/core/test/transactions.test.ts
+++ b/packages/core/test/transactions.test.ts
@@ -264,6 +264,61 @@ describe("Transactions", () => {
       expect(init.headers.Authorization).toBe(`Bearer ${PRIVATE_KEY}`);
     });
 
+    it("should forward the second acceptance token and the optional documented fields", async () => {
+      const transactions = makeClient(PRIVATE_KEY);
+
+      mockFetch.mockResolvedValueOnce(okJson(TRANSACTION_RESPONSE));
+
+      const [error] = await transactions.createTransaction({
+        acceptance_token: "eyJhb...",
+        accept_personal_auth: "eyJwZXJz...",
+        amount_in_cents: 3000000,
+        currency: "COP",
+        signature: "sig_123",
+        customer_email: "test@example.com",
+        reference: "ref-123",
+        payment_method: { type: "CARD", token: "tok_123", installments: 1 },
+        taxes: [{ type: "VAT", amount_in_cents: 478000 }],
+        ip: "190.0.0.1",
+        recurrent: true,
+        parent_transaction_id: "txn-parent",
+      });
+
+      expect(error).toBeNull();
+
+      const [, options] = mockFetch.mock.calls[0]!;
+      expect(JSON.parse(options.body)).toMatchObject({
+        acceptance_token: "eyJhb...",
+        accept_personal_auth: "eyJwZXJz...",
+        taxes: [{ type: "VAT", amount_in_cents: 478000 }],
+        ip: "190.0.0.1",
+        recurrent: true,
+        parent_transaction_id: "txn-parent",
+      });
+    });
+
+    it("should forward undocumented fields instead of stripping them", async () => {
+      const transactions = makeClient(PRIVATE_KEY);
+
+      mockFetch.mockResolvedValueOnce(okJson(TRANSACTION_RESPONSE));
+
+      const [error] = await transactions.createTransaction({
+        acceptance_token: "eyJhb...",
+        amount_in_cents: 3000000,
+        currency: "COP",
+        signature: "sig_123",
+        customer_email: "test@example.com",
+        reference: "ref-123",
+        payment_method: { type: "CARD", token: "tok_123", installments: 1 },
+        future_field_wompi_added: "keep me",
+      });
+
+      expect(error).toBeNull();
+
+      const [, options] = mockFetch.mock.calls[0]!;
+      expect(JSON.parse(options.body)).toMatchObject({ future_field_wompi_added: "keep me" });
+    });
+
     it("should return [error, null] on invalid input", async () => {
       const transactions = makeClient(PRIVATE_KEY);
 


### PR DESCRIPTION
Implements the required fixes from `.plans/production-readiness-audit.md` (P0 + P1) and the concrete items from `.plans/wompi-rag-assistant-gaps.md`.

## `@pulgueta/wompi-convex` (minor)

- **1.2 Web Checkout retry** — `applyChargeOutcome` now lets `declined | error | expired → approved | voided`. A later transaction that shares the reference supersedes the previous id (`supersededTransactionIds`). Reconciliation prefers `APPROVED`, then newest.
- **2.1 Transport errors** — a charge whose response never arrived (network, 5xx, 408/429, unparsable 2xx) is left `pending` (`outcome: "unresolved"`) instead of `error`. The next claim reuses the same reference; Wompi rejects the duplicate and the existing transaction is applied. The sweep now looks tx-less rows up by reference (server-side charges every run, checkouts once before expiring). Only rejected requests (4xx) finalize.
- **2.2 Double `subscribe`** — any pending payment on an `incomplete`/`unpaid` subscription is returned as-is; no second reference is minted.
- **2.3 Payments webhook** — a duplicate delivery whose first attempt crashed after `recordEvent` (no outcome) is reprocessed, mirroring the payouts path.
- **2.4 `api().confirmTransaction`** — requires `getUserInfo`; payments of other users are redacted to the outcome code.
- **2.5 `api().checkout`** — public action takes only `{ redirectUrl, productKey }`; custom amounts/metadata stay on `wompi.checkout(ctx, …)`.
- **2.6 Acceptance tokens** — sends `accept_personal_auth` with payment sources and charges; `useWompiTokenizer` exposes `personalDataAuthPermalink`; payment sources record `termsAcceptedAt`.
- **1.1 Packaging** — `publishConfig.access: public`, `build` always cleans `dist`/tsbuildinfo, `react` peer optional, PUBLISHING.md rewritten to the changesets flow.
- README: checkout/confirm semantics, callback delivery guarantees, security model.

## `@pulgueta/wompi` (minor)

- **2.6/2.7** `accept_personal_auth` on `createTransaction`/`createPaymentSource`, `presigned_personal_data_auth` on merchants; input schemas are `.loose()` and name `taxes`, `ip`, `recurrent`, `parent_transaction_id`, `payment_method_type`, `payment_description`.
- **2.8** payment-source `type` accepts `DAVIPLATA`/`BANCOLOMBIA_TRANSFER`, `status` accepts `VOIDED`; response schemas use plain strings.
- Docs (`transactions`, `payment-sources`, `merchants`, quickstart/card-checkout examples), README and skills updated.

## CI

- `test.yaml` packs both publishable packages with `pnpm pack` and fails if a manifest still contains `workspace:` (root cause of the uninstallable `0.2.0`).

## Example app (RAG assistant gaps)

- Chat/embedding model ids read from `AI_GATEWAY_CHAT_MODEL` / `AI_GATEWAY_EMBEDDING_MODEL` (defaults unchanged).
- Docs are tagged with a `section` at ingest; `searchWompiDocs` accepts an optional `section` filter.
- README: `stopWhen` trap, model env vars, re-ingest note. FAB z-index item was already resolved.

## Tests

- Component: 66 (was 54) — payer retry under one reference, expired→approved→voided, double subscribe, transport error → pending → reconcile on next claim, 4xx finalizes, sweep-by-reference before expiry, webhook 403 / crash-then-retry, `api()` auth wiring, `confirmTransaction` redaction, `checkout` args.
- Core: 231 (was 223) — new input fields forwarded, DAVIPLATA/VOIDED responses parse, `presigned_personal_data_auth`.

## Not done / manual

- Deprecating `@pulgueta/wompi-convex@0.2.0` on npm needs npm auth — run `npm deprecate @pulgueta/wompi-convex@0.2.0 "workspace: dependency; use >=0.3.0"` after the release PR publishes.
- The RAG `section` filter only covers documents re-ingested after this change (new namespace version).
- P2/P3 audit items and the plan-level RAG items (cron re-ingest, `/llms` export, message-parts renderer) are out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added personal-data authorization acceptance tokens across checkout, transactions, payment sources, and subscriptions.
  - Expanded payment-source support with additional types, statuses, descriptions, and terms-acceptance details.
  - Checkout now uses catalog product keys, with authenticated transaction details and privacy-safe payment visibility.
  - Improved payment retries, reconciliation, duplicate submissions, and webhook handling.

- **Documentation**
  - Updated guides, examples, and integration skills for new payment workflows.
  - Added configurable AI models and documentation-section filtering guidance.

- **Bug Fixes**
  - Improved recovery of delayed approvals, voids, and failed webhook deliveries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR hardens billing recovery and reconciliation, adds personal-data authorization tokens throughout the SDK, restricts public checkout and confirmation APIs, and improves package-release validation.
- Reuses payment references across unresolved charges and reconciles late transaction outcomes.
- Reprocesses webhook records that lack a completed outcome.
- Adds both Wompi acceptance tokens and broadens supported payment-source schemas.
- Updates package publishing, documentation, tests, and example-app RAG configuration.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no blocking failure remains.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/convex-component/src/client/index.ts | Adds retry-aware webhook processing, reference reconciliation, authenticated confirmation redaction, restricted public checkout arguments, and acceptance-token forwarding. |
| packages/convex-component/src/component/billing.ts | Expands the billing state machine to reconcile later transactions and preserve superseded transaction identifiers. |
| packages/convex-component/src/component/subscriptions.ts | Reuses pending subscription payments and tracks resume attempts to avoid duplicate charges. |
| packages/core/src/payments-schemas.ts | Adds personal-data authorization fields, forwards documented transaction inputs, and broadens payment-source response compatibility. |
| .github/workflows/test.yaml | Packs publishable packages in CI and rejects tarballs containing unresolved workspace dependency specifiers. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Charge or webhook result] --> B{Existing payment reference?}
  B -->|No| C[Create pending payment]
  B -->|Yes| D[Reuse pending payment]
  C --> E[Submit or reconcile with Wompi]
  D --> E
  E --> F{Outcome resolved?}
  F -->|No| G[Keep pending for retry or sweep]
  F -->|Yes| H[Apply approved declined expired or voided state]
  H --> I[Record webhook outcome]
  I --> J[Invoke configured callbacks]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["style(docs): format acceptance-token exa..."](https://github.com/pulgueta/wompi-node/commit/8875eabf4c52b5945a7183239a60d37dd35be9f6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54436504)</sub>

<!-- /greptile_comment -->